### PR TITLE
Apt: Better php pin

### DIFF
--- a/manala.apt/tests/030_preferences.jessie.goss.yml
+++ b/manala.apt/tests/030_preferences.jessie.goss.yml
@@ -19,7 +19,7 @@ file:
     exists:   true
     filetype: file
     contains:
-      - "Package:      php-* php5-* php5.6-* php7.0-* php7.1-*"
+      - "Package:      dh-php libapache2-mod-php* libphp* php php-* /^php[1-9]+/ pkg-php-tools"
       - "Pin:          origin packages.dotdeb.org"
       - "Pin-Priority: 300"
   /etc/apt/preferences.d/dotdeb:

--- a/manala.apt/tests/030_preferences.wheezy.goss.yml
+++ b/manala.apt/tests/030_preferences.wheezy.goss.yml
@@ -19,7 +19,7 @@ file:
     exists:   true
     filetype: file
     contains:
-      - "Package:      php-* php5-* php5.6-* php7.0-* php7.1-*"
+      - "Package:      dh-php libapache2-mod-php* libphp* php php-* /^php[1-9]+/ pkg-php-tools"
       - "Pin:          origin packages.dotdeb.org"
       - "Pin-Priority: 300"
   /etc/apt/preferences.d/dotdeb:

--- a/manala.apt/vars/main.yml
+++ b/manala.apt/vars/main.yml
@@ -347,7 +347,7 @@ manala_apt_keys_patterns:
 manala_apt_preferences_patterns:
   vim:                vim*
   git:                git git-*
-  php:                php-* php5-* php5.6-* php7.0-* php7.1-*
+  php:                dh-php libapache2-mod-php* libphp* php php-* /^php[1-9]+/ pkg-php-tools
   mysql:              mysql* libmysql*
   nginx:              nginx*
   ruby:               ruby*


### PR DESCRIPTION
According to apt preferences man (http://man.he.net/man5/apt_preferences), we can now use regex, and stop to add pins for each new php version.
Must pass:
- php
- php-foo
- php5
- php5-foo
- php5.6
- php5.6-foo
- php7.0
- php7.0-foo
- php7.1
- php7.1-goo
- ...

Must *NOT* pass:
- phpab
- phpbb3
- phpmyadmin
- ...
