### PR TITLE
Apt: Update the default pin priority from 900 to 990

### DIFF
--- a/manala.apt/README.md
+++ b/manala.apt/README.md
@@ -206,7 +206,7 @@ manala_apt_preferences:
     file:     dotdeb
   - package:  'php-*'
     pin:      release o=Debian,a=stable
-    priority: 900
+    priority: 990
     file:     php
 ```
 

--- a/manala.apt/lookup_plugins/manala_apt_preferences.py
+++ b/manala.apt/lookup_plugins/manala_apt_preferences.py
@@ -55,7 +55,7 @@ class LookupModule(LookupBase):
                     'priority': int(
                         (term.split(':')[1])
                             if len(term.split(':')) > 1 else
-                        (900)
+                        (990)
                     )
                 })
 

--- a/manala.apt/tests/030_preferences.jessie.goss.yml
+++ b/manala.apt/tests/030_preferences.jessie.goss.yml
@@ -7,14 +7,14 @@ file:
     contains:
       - "Package:      git git-*"
       - "Pin:          release a=jessie-backports"
-      - "Pin-Priority: 900"
+      - "Pin-Priority: 990"
   /etc/apt/preferences.d/libssl1_0_0:
     exists:   true
     filetype: file
     contains:
       - "Package:      libssl1.0.0"
       - "Pin:          release a=jessie-backports"
-      - "Pin-Priority: 900"
+      - "Pin-Priority: 990"
   /etc/apt/preferences.d/php:
     exists:   true
     filetype: file

--- a/manala.apt/tests/030_preferences.wheezy.goss.yml
+++ b/manala.apt/tests/030_preferences.wheezy.goss.yml
@@ -7,14 +7,14 @@ file:
     contains:
       - "Package:      git git-*"
       - "Pin:          release a=wheezy-backports"
-      - "Pin-Priority: 900"
+      - "Pin-Priority: 990"
   /etc/apt/preferences.d/libssl1_0_0:
     exists:   true
     filetype: file
     contains:
       - "Package:      libssl1.0.0"
       - "Pin:          release a=wheezy-backports"
-      - "Pin-Priority: 900"
+      - "Pin-Priority: 990"
   /etc/apt/preferences.d/php:
     exists:   true
     filetype: file


### PR DESCRIPTION
According to apt preferences man (http://man.he.net/man5/apt_preferences), although it's kinda cryptic, we should use 990 instead of 900