### PR TITLE
Remove npm packages update handling

### DIFF
--- a/manala.skeleton/vars/main.yml
+++ b/manala.skeleton/vars/main.yml
@@ -137,6 +137,12 @@ manala_skeleton_patterns:
     }}"
     # MailHog
     mailhog_config_template: config/default.{{ manala_skeleton_env }}.j2
+    # Npm
+    npm:
+      # Force npm update to false, even if global manala.update si set to true.
+      # In case of a project setup, update npm itself (as a global npm package)
+      # could lead to unwanted behaviors
+      update: false
     # Supervisor
     supervisor_config_template: config/default.{{ manala_skeleton_env }}.j2
     supervisor_configs_exclusive: true


### PR DESCRIPTION
Automatically update global npm packages lead to totally unwanted behavior, where npm is itself updated across nodejs version.
Indeed, npm versions are softly mapped to nodejs versions ( 2/4, 3/5, 3/6, 4/7, 5/8), and - for instance - going to npm 5  with node < 8 could break toys.