### PR TITLE
[Skeleton] Fix httpie installation

### DIFF
--- a/manala.skeleton/CHANGELOG.md
+++ b/manala.skeleton/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Limit httpie installation on jessie
 
 ### Added
-- Respect httpie dependencies (python3-requests >= 2.5.2, available on backports)
+- Respect httpie dependencies (python3-requests >= 2.5.2, python3-urllib3 >= 1.16, available on backports)
 
 ## [1.0.2] - 2017-06-14
 ### Added

--- a/manala.skeleton/CHANGELOG.md
+++ b/manala.skeleton/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Limit httpie installation on jessie
+
+### Added
+- Respect httpie dependencies (python3-requests >= 2.5.2, available on backports)
 
 ## [1.0.2] - 2017-06-14
 ### Added

--- a/manala.skeleton/vars/main.yml
+++ b/manala.skeleton/vars/main.yml
@@ -54,7 +54,8 @@ manala_skeleton_patterns:
         'jessie': [
           'git@backports',
           'htop@backports',
-          'httpie@manala'
+          'httpie@manala',
+          'python3-requests@backports'
         ]
       }[ansible_distribution_release]
       + (manala_skeleton_options.docker)|ternary(['docker@docker'],[])

--- a/manala.skeleton/vars/main.yml
+++ b/manala.skeleton/vars/main.yml
@@ -55,7 +55,8 @@ manala_skeleton_patterns:
           'git@backports',
           'htop@backports',
           'httpie@manala',
-          'python3-requests@backports'
+          'python3-requests@backports',
+          'python3-urllib3@backports'
         ]
       }[ansible_distribution_release]
       + (manala_skeleton_options.docker)|ternary(['docker@docker'],[])

--- a/manala.skeleton/vars/main.yml
+++ b/manala.skeleton/vars/main.yml
@@ -42,8 +42,7 @@ manala_skeleton_patterns:
     apt_preferences_exclusive: true
     apt_preferences: "{{
       [
-        'thefuck@manala',
-        'httpie@manala'
+        'thefuck@manala'
       ]
       + {
         'wheezy': [
@@ -54,7 +53,8 @@ manala_skeleton_patterns:
         ],
         'jessie': [
           'git@backports',
-          'htop@backports'
+          'htop@backports',
+          'httpie@manala'
         ]
       }[ansible_distribution_release]
       + (manala_skeleton_options.docker)|ternary(['docker@docker'],[])
@@ -391,16 +391,25 @@ manala_skeleton_patterns:
 
   manala_dev: &pattern_manala_dev
     # Apt
-    apt_packages:
-      - debfoster
-      - rsync
-      - curl
-      - htop
-      - less
-      - ssl-cert
-      - thefuck
-      - gitsplit
-      - httpie
+    apt_packages: "{{
+      [
+        'debfoster',
+        'rsync',
+        'curl',
+        'htop',
+        'less',
+        'ssl-cert',
+        'thefuck',
+        'gitsplit'
+      ]
+      + {
+        'wheezy': [
+        ],
+        'jessie': [
+          'httpie'
+        ]
+      }[ansible_distribution_release]
+    }}"
     # Supervisor
     supervisor_configs:
       - file:     inet-http-server.conf


### PR DESCRIPTION
- [x] Limit httpie installation on jessie
- [x] Respect httpie dependencies (python3-requests >= 2.5.2, python3-urllib3 >= 1.16, available on backports)