### PR TITLE
[Pam Ssh Agent Auth] Change package

### DIFF
--- a/manala.apt/CHANGELOG.md
+++ b/manala.apt/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Pam Ssh Agent Auth preferences pattern
 
 ## [1.0.7] - 2017-10-20
 ### Fixed

--- a/manala.apt/vars/main.yml
+++ b/manala.apt/vars/main.yml
@@ -382,7 +382,7 @@ manala_apt_preferences_patterns:
   docker:             docker*
   chrony:             chrony*
   backup-manager:     backup-manager*
-  pam-ssh-agent-auth: pam-ssh-agent-auth*
+  pam-ssh-agent-auth: libpam-ssh-agent-auth*
   oauth2-proxy:       oauth2-proxy*
   cloud:              cloud-init cloud-utils
   mariadb:            mariadb* libmariadb*

--- a/manala.pam-ssh-agent-auth/CHANGELOG.md
+++ b/manala.pam-ssh-agent-auth/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Package
 
 ## [1.0.0] - 2017-07-17
 ### Added

--- a/manala.pam-ssh-agent-auth/README.md
+++ b/manala.pam-ssh-agent-auth/README.md
@@ -8,7 +8,7 @@ It's part of the [Manala Ansible stack](http://www.manala.io) but can be used as
 
 ## Requirements
 
-This role is made to work with the __manala__ pam-ssh-agent-auth debian package, available on the __manala__ debian repository. Please use the [**manala.apt**](https://galaxy.ansible.com/manala/apt/) role to handle it properly.
+This role is made to work with the __manala__ libpam-ssh-agent-auth debian package, available on the __manala__ debian repository. Please use the [**manala.apt**](https://galaxy.ansible.com/manala/apt/) role to handle it properly.
 
 ```yaml
 manala_apt_preferences:

--- a/manala.pam-ssh-agent-auth/tasks/install.yml
+++ b/manala.pam-ssh-agent-auth/tasks/install.yml
@@ -8,4 +8,4 @@
     update_cache:       true
     cache_valid_time:   3600
   with_items:
-    - pam-ssh-agent-auth
+    - libpam-ssh-agent-auth

--- a/manala.pam-ssh-agent-auth/tests/0100_install.goss.yml
+++ b/manala.pam-ssh-agent-auth/tests/0100_install.goss.yml
@@ -1,5 +1,5 @@
 ---
 
 package:
-  pam-ssh-agent-auth:
+  libpam-ssh-agent-auth:
     installed: true

--- a/manala.pam-ssh-agent-auth/tests/0100_install.yml
+++ b/manala.pam-ssh-agent-auth/tests/0100_install.yml
@@ -8,7 +8,7 @@
     - copy:
         dest: /etc/apt/preferences.d/pam-ssh-agent-auth
         content: |
-          Package:      pam-ssh-agent-auth*
+          Package:      libpam-ssh-agent-auth*
           Pin:          origin debian.manala.io
           Pin-Priority: 900
   roles:

--- a/manala.pam-ssh-agent-auth/tests/0200_sudo.yml
+++ b/manala.pam-ssh-agent-auth/tests/0200_sudo.yml
@@ -8,7 +8,7 @@
     - copy:
         dest: /etc/apt/preferences.d/pam-ssh-agent-auth
         content: |
-          Package:      pam-ssh-agent-auth*
+          Package:      libpam-ssh-agent-auth*
           Pin:          origin debian.manala.io
           Pin-Priority: 900
   roles:


### PR DESCRIPTION
Long story short: package is now available upstream (see: https://packages.debian.org/sid/libpam-ssh-agent-auth), and following the debian rules, changed its name from `libpam-ssh-agent-auth` to `pam-ssh-agent-auth`.

Btw, to keep a decent version, we still use by default our backported version

