### PR TITLE
Use hosts exclusion on tests

### DIFF
--- a/manala.elasticsearch/tests/0204_install.5.yml
+++ b/manala.elasticsearch/tests/0204_install.5.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts:
-    - debian.jessie
-    - debian.stretch
+  hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
     - include: pre_tasks/elasticsearch_5.yml

--- a/manala.elasticsearch/tests/0304_config.5.yml
+++ b/manala.elasticsearch/tests/0304_config.5.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts:
-    - debian.jessie
-    - debian.stretch
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_elasticsearch_config:

--- a/manala.java/tests/0102_install.8.yml
+++ b/manala.java/tests/0102_install.8.yml
@@ -1,9 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts:
-    - debian.jessie
-    - debian.stretch
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_java_version: 8

--- a/manala.nodejs/tests/0103_install.5.yml
+++ b/manala.nodejs/tests/0103_install.5.yml
@@ -2,8 +2,8 @@
 
 - name: "{{ test }}"
   hosts:
-      - debian.wheezy
-      - debian.jessie
+    - debian.wheezy
+    - debian.jessie
   become: true
   pre_tasks:
     - include: pre_tasks/nodesource_5.yml

--- a/manala.nodejs/tests/0105_install.7.yml
+++ b/manala.nodejs/tests/0105_install.7.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian.jessie
+  hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
     - include: pre_tasks/nodesource_7.yml

--- a/manala.nodejs/tests/0106_install.8.yml
+++ b/manala.nodejs/tests/0106_install.8.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian.jessie
+  hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
     - include: pre_tasks/nodesource_8.yml

--- a/manala.nodejs/tests/0107_install.9.yml
+++ b/manala.nodejs/tests/0107_install.9.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian.jessie
+  hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
     - include: pre_tasks/nodesource_9.yml


### PR DESCRIPTION
I've just realized that we left behind some tests during debian stretch support.
Why ?
Because, we need to specify each distribution individually when we don't supports all of them.

Let's see an example, where - before stretch support - we wanted to exclude wheezy:

```
hosts:
  - debian.jessie
```

It's easy to forgot to add an `debian.stretch` key, because the intention is not clear. Jessie only ? All but wheezy ?

Now, same example using ansible host exclusion (http://docs.ansible.com/ansible/latest/intro_patterns.html):

```
hosts:
  - debian:!debian.wheezy
```

Aaaaah ! Nice, the intention is clear, and nothing to specify for adding stretch support :)

So, to focus on a specific distribution:

```
hosts: debian.jessie
```

So, to focus on a specific distributions, without forward compatibility:

```
hosts:
  - debian.wheezy
  - debian.jessie
```

So, to focus on all distributions, without backward compatibility:

```
hosts: debian:!debian.wheezy
```