### PR TITLE
[Php] Allow to pass 'env' variables to php pools

### DIFF
--- a/manala.php/CHANGELOG.md
+++ b/manala.php/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Allow to pass 'env' variables to php pools
 
 ## [1.0.5] - 2017-12-08
 ### Added

--- a/manala.php/README.md
+++ b/manala.php/README.md
@@ -155,6 +155,9 @@ manala_php_cli_configs:
 ```yaml
 manala_php_fpm_pools:
   - file: www.conf
+    env:
+      foo: bar
+      app_env: prod
     config:
       - www:
         - pm.max_children:          5

--- a/manala.php/templates/fpm_pools/5.6/_base.j2
+++ b/manala.php/templates/fpm_pools/5.6/_base.j2
@@ -465,6 +465,8 @@
   'php_admin_value[memory_limit]'
 ] + config_extra.keys()) -}}
 
+{{ macros.pool_env(item) }}
+
     {%- endfor %}
 
 

--- a/manala.php/templates/fpm_pools/5/_base.j2
+++ b/manala.php/templates/fpm_pools/5/_base.j2
@@ -465,6 +465,8 @@
   'php_admin_value[memory_limit]'
 ] + config_extra.keys()) -}}
 
+{{ macros.pool_env(item) }}
+
     {%- endfor %}
 
 

--- a/manala.php/templates/fpm_pools/7.0/_base.j2
+++ b/manala.php/templates/fpm_pools/7.0/_base.j2
@@ -467,6 +467,8 @@
   'php_admin_value[memory_limit]'
 ] + config_extra.keys()) -}}
 
+{{ macros.pool_env(item) }}
+
     {%- endfor %}
 
 

--- a/manala.php/templates/fpm_pools/7.1/_base.j2
+++ b/manala.php/templates/fpm_pools/7.1/_base.j2
@@ -467,6 +467,8 @@
   'php_admin_value[memory_limit]'
 ] + config_extra.keys()) -}}
 
+{{ macros.pool_env(item) }}
+
     {%- endfor %}
 
 

--- a/manala.php/templates/fpm_pools/7.2/_base.j2
+++ b/manala.php/templates/fpm_pools/7.2/_base.j2
@@ -472,6 +472,8 @@
   'php_admin_value[memory_limit]'
 ] + config_extra.keys()) -}}
 
+{{ macros.pool_env(item) }}
+
     {%- endfor %}
 
 

--- a/manala.php/templates/fpm_pools/_macros.j2
+++ b/manala.php/templates/fpm_pools/_macros.j2
@@ -62,3 +62,10 @@
         {{ value }}
     {%- endif -%}
 {%- endmacro -%}
+
+{%- macro pool_env(pool) -%}
+    {%- set variables = pool.env|default({}) -%}
+    {%- for key, value in variables.iteritems() -%}
+        env[{{ key }}] = {{ value }}{{ '\n' }}
+    {%- endfor -%}
+{%- endmacro -%}

--- a/manala.php/tests/0600_fpm_pools.5.4.goss.yml
+++ b/manala.php/tests/0600_fpm_pools.5.4.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /var/run/php5-fpm.sock"
   /etc/php5/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php5/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0600_fpm_pools.5.4.yml
+++ b/manala.php/tests/0600_fpm_pools.5.4.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/dotdeb.yml
     - apt:

--- a/manala.php/tests/0601_fpm_pools.5.5.goss.yml
+++ b/manala.php/tests/0601_fpm_pools.5.5.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /var/run/php5-fpm.sock"
   /etc/php5/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php5/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0601_fpm_pools.5.5.yml
+++ b/manala.php/tests/0601_fpm_pools.5.5.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/dotdeb_wheezy_55.yml
     - apt:

--- a/manala.php/tests/0602_fpm_pools.5.6_dotdeb.goss.yml
+++ b/manala.php/tests/0602_fpm_pools.5.6_dotdeb.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /var/run/php5-fpm.sock"
   /etc/php5/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php5/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
+++ b/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/dotdeb_wheezy_56.yml
     - apt:

--- a/manala.php/tests/0603_fpm_pools.5.6.goss.yml
+++ b/manala.php/tests/0603_fpm_pools.5.6.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /run/php/php5.6-fpm.sock"
   /etc/php/5.6/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php/5.6/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0603_fpm_pools.5.6.yml
+++ b/manala.php/tests/0603_fpm_pools.5.6.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/sury_php.yml
     - apt:

--- a/manala.php/tests/0604_fpm_pools.7.0_dotdeb.goss.yml
+++ b/manala.php/tests/0604_fpm_pools.7.0_dotdeb.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /run/php/php7.0-fpm.sock"
   /etc/php/7.0/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php/7.0/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
+++ b/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/dotdeb.yml
     - apt:

--- a/manala.php/tests/0605_fpm_pools.7.0.goss.yml
+++ b/manala.php/tests/0605_fpm_pools.7.0.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /run/php/php7.0-fpm.sock"
   /etc/php/7.0/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php/7.0/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0605_fpm_pools.7.0.yml
+++ b/manala.php/tests/0605_fpm_pools.7.0.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/sury_php.yml
     - apt:

--- a/manala.php/tests/0606_fpm_pools.7.1.goss.yml
+++ b/manala.php/tests/0606_fpm_pools.7.1.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /run/php/php7.1-fpm.sock"
   /etc/php/7.1/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php/7.1/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0606_fpm_pools.7.1.yml
+++ b/manala.php/tests/0606_fpm_pools.7.1.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/sury_php.yml
     - apt:

--- a/manala.php/tests/0607_fpm_pools.7.2.goss.yml
+++ b/manala.php/tests/0607_fpm_pools.7.2.goss.yml
@@ -9,3 +9,9 @@ file:
       - "listen = /run/php/php7.2-fpm.sock"
   /etc/php/7.2/fpm/pool.d/bar.conf:
     exists: false
+  /etc/php/7.2/fpm/pool.d/env.conf:
+    exists:   true
+    filetype: file
+    contains:
+      - "env[FOO] = bar"
+      - "env[BAR] = 2"

--- a/manala.php/tests/0607_fpm_pools.7.2.yml
+++ b/manala.php/tests/0607_fpm_pools.7.2.yml
@@ -15,6 +15,15 @@
         config:
           - www:
             - pm.max_children: 12
+      - file:     env.conf
+        template: fpm_pools/default.j2
+        env:
+          FOO: bar
+          BAR: 1
+        config:
+          - env:
+            - listen: /run/php-fpm.env.sock
+            - env[BAR]: 2
   pre_tasks:
     - include: pre_tasks/sury_php.yml
     - apt:


### PR DESCRIPTION
Allow to pass environment variables to php pools : 

# Variables precedence

Env variables defined in `config` overwrite variables defined in `pool`.

```yml
manala_php_fpm_pools:
  - file:  www.conf
    template: fpm_pools/default.j2
    env:
      FOO: bar
      BAR: 1
    config:
      - www:
        - env[BAR]: 2
```

```php
# var_dump(getenv());
array(4) {
  ["BAR"]=>
  string(1) "2"
  ["FOO"]=>
  string(3) "bar"
}
```

# Variables types

Env variables are casted to string :

```yaml
manala_php_fpm_pools:
  - file: www.conf
     template: fpm_pools/default.j2
     www:
       bool: yes
       int: 1
       float: 1.0
       string: hello
```

```php
# var_dump(getenv());
array(7) {
  ["string"]=>
  string(5) "hello"
  ["bool"]=>
  string(1) "1"
  ["float"]=>
  string(3) "1.0"
  ["int"]=>
  string(1) "1"
}
```

# Variables order

Variables order is not preserved.