### PR TITLE
[Environment] Support non-scalar variable intepretation only in legacy mode

### DIFF
--- a/manala.environment/CHANGELOG.md
+++ b/manala.environment/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Support non-scalar variable intepretation only in legacy mode
 
 ## [1.0.2] - 2017-12-14
 ### Added

--- a/manala.environment/CHANGELOG.md
+++ b/manala.environment/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Support non-scalar variable intepretation only in legacy mode
 
+### Changed
+- Alphabetically sort variables
+
 ## [1.0.2] - 2017-12-14
 ### Added
 - Support variables as dict

--- a/manala.environment/README.md
+++ b/manala.environment/README.md
@@ -39,6 +39,8 @@ Using ansible galaxy requirements file:
 
 ### Configuration example
 
+Note that only string, integer or float variables are supported.
+
 ```yaml
 manala_environment_files:
   - pam # /etc/environment
@@ -52,12 +54,16 @@ manala_environment_variables:
 ```
 
 For legacy purposes, `manala_environment_variables` also accepts values as
-a dictionnary list:
+a dictionnary list.
+Note that in this mode (and only in this mode), some non-scalar values are
+interpreted to strings.
 
 ```yaml
 manala_environment_variables:
   - FOO: bar
-  - BAR: true
+  - FOO_NULL: ~      # -> "null"
+  - FOO_TRUE: true   # -> "true"
+  - FOO_FALSE: false # -> "false"
 ```
 
 ## Example playbook

--- a/manala.environment/lookup_plugins/manala_environment_variables.py
+++ b/manala.environment/lookup_plugins/manala_environment_variables.py
@@ -6,7 +6,7 @@ from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
 
-    def format_value(self, value):
+    def legacy_format_value(self, value):
         if (value is None):
             return 'null'
         elif (value is True):
@@ -22,9 +22,11 @@ class LookupModule(LookupBase):
 
         if isinstance(terms[0], dict):
             for name, value in terms[0].iteritems():
+                if not isinstance(value, (basestring, int, float)) or isinstance(value, bool):
+                    raise AnsibleError("Expected a string, an integer or a float for key \"%s\" in manala_environment_variables" % name)
                 results.append({
                     'name':  name,
-                    'value': self.format_value(value)
+                    'value': value
                 })
         else:
             # Legacy
@@ -40,13 +42,13 @@ class LookupModule(LookupBase):
                     # Expanded syntax
                     items.append({
                         'name':  term.get('name'),
-                        'value': self.format_value(term.get('value'))
+                        'value': self.legacy_format_value(term.get('value'))
                     })
                 else:
                     # Short syntax
                     items.append({
                         'name':  term.keys()[0],
-                        'value': self.format_value(term.values()[0])
+                        'value': self.legacy_format_value(term.values()[0])
                     })
 
                 # Merge by index key

--- a/manala.environment/lookup_plugins/manala_environment_variables.py
+++ b/manala.environment/lookup_plugins/manala_environment_variables.py
@@ -21,7 +21,8 @@ class LookupModule(LookupBase):
         results = []
 
         if isinstance(terms[0], dict):
-            for name, value in terms[0].iteritems():
+            for name in sorted(terms[0]):
+                value = terms[0].get(name)
                 if not isinstance(value, (basestring, int, float)) or isinstance(value, bool):
                     raise AnsibleError("Expected a string, an integer or a float for key \"%s\" in manala_environment_variables" % name)
                 results.append({

--- a/manala.environment/tests/0100_variables.goss.yml
+++ b/manala.environment/tests/0100_variables.goss.yml
@@ -5,24 +5,27 @@ file:
     exists: true
     filetype: file
     contains:
-      - 'BAZ="baz"'
-      - 'FOO="foo"'
+      - '_FOO="bar"'
+      - '_BAR="123"'
       - 'BAR="123"'
+      - 'BAZ="1.2"'
       - 'FOO="bar"'
-      - 'QUZ="1.2"'
+      - 'QUX="foo=bar"'
   /etc/zsh/zshenv:
     exists: true
     filetype: file
     contains:
       - '# /etc/zsh/zshenv'
       - 'export BAR="123"'
+      - 'export BAZ="1.2"'
       - 'export FOO="bar"'
-      - 'export QUZ="1.2"'
+      - 'export QUX="foo=bar"'
   /etc/profile.d/test.sh:
     exists: true
     filetype: file
     contains:
       - '# /etc/profile.d/test.sh'
       - 'export BAR="123"'
+      - 'export BAZ="1.2"'
       - 'export FOO="bar"'
-      - 'export QUZ="1.2"'
+      - 'export QUX="foo=bar"'

--- a/manala.environment/tests/0100_variables.goss.yml
+++ b/manala.environment/tests/0100_variables.goss.yml
@@ -6,28 +6,23 @@ file:
     filetype: file
     contains:
       - 'BAZ="baz"'
+      - 'FOO="foo"'
       - 'FOO="bar"'
-      - 'BAR="baz"'
-      - 'FOO_NULL="null"'
-      - 'FOO_TRUE="true"'
-      - 'FOO_FALSE="false"'
+      - 'BAR="123"'
+      - 'QUZ="1.2"'
   /etc/zsh/zshenv:
     exists: true
     filetype: file
     contains:
       - '# /etc/zsh/zshenv'
       - 'export FOO="bar"'
-      - 'export BAR="baz"'
-      - 'export FOO_NULL="null"'
-      - 'export FOO_TRUE="true"'
-      - 'export FOO_FALSE="false"'
+      - 'export BAR="123"'
+      - 'export QUZ="1.2"'
   /etc/profile.d/test.sh:
     exists: true
     filetype: file
     contains:
       - '# /etc/profile.d/test.sh'
       - 'export FOO="bar"'
-      - 'export BAR="baz"'
-      - 'export FOO_NULL="null"'
-      - 'export FOO_TRUE="true"'
-      - 'export FOO_FALSE="false"'
+      - 'export BAR="123"'
+      - 'export QUZ="1.2"'

--- a/manala.environment/tests/0100_variables.goss.yml
+++ b/manala.environment/tests/0100_variables.goss.yml
@@ -7,22 +7,22 @@ file:
     contains:
       - 'BAZ="baz"'
       - 'FOO="foo"'
-      - 'FOO="bar"'
       - 'BAR="123"'
+      - 'FOO="bar"'
       - 'QUZ="1.2"'
   /etc/zsh/zshenv:
     exists: true
     filetype: file
     contains:
       - '# /etc/zsh/zshenv'
-      - 'export FOO="bar"'
       - 'export BAR="123"'
+      - 'export FOO="bar"'
       - 'export QUZ="1.2"'
   /etc/profile.d/test.sh:
     exists: true
     filetype: file
     contains:
       - '# /etc/profile.d/test.sh'
-      - 'export FOO="bar"'
       - 'export BAR="123"'
+      - 'export FOO="bar"'
       - 'export QUZ="1.2"'

--- a/manala.environment/tests/0100_variables.yml
+++ b/manala.environment/tests/0100_variables.yml
@@ -11,10 +11,8 @@
         export: true
     manala_environment_variables:
       FOO: bar
-      BAR: baz
-      FOO_NULL:  null
-      FOO_TRUE:  true
-      FOO_FALSE: false
+      BAR: 123
+      QUZ: 1.2
   pre_tasks:
     - copy:
         dest: /etc/environment

--- a/manala.environment/tests/0100_variables.yml
+++ b/manala.environment/tests/0100_variables.yml
@@ -12,13 +12,14 @@
     manala_environment_variables:
       FOO: bar
       BAR: 123
-      QUZ: 1.2
+      BAZ: 1.2
+      QUX: foo=bar
   pre_tasks:
     - copy:
         dest: /etc/environment
         content: |
-          BAZ="baz"
-          FOO="foo"
+          _FOO="bar"
+          _BAR="123"
     - file:
         path: /etc/zsh
         state: directory

--- a/manala.environment/tests/0101_variables_legacy.goss.yml
+++ b/manala.environment/tests/0101_variables_legacy.goss.yml
@@ -5,9 +5,12 @@ file:
     exists: true
     filetype: file
     contains:
-      - 'BAZ="baz"'
+      - '_FOO="bar"'
+      - '_BAR="123"'
       - 'FOO="bar"'
-      - 'BAR="baz"'
+      - 'BAR="123"'
+      - 'BAZ="1.2"'
+      - 'QUX="foo=bar"'
       - 'FOO_NULL="null"'
       - 'FOO_TRUE="true"'
       - 'FOO_FALSE="false"'
@@ -17,7 +20,9 @@ file:
     contains:
       - '# /etc/zsh/zshenv'
       - 'export FOO="bar"'
-      - 'export BAR="baz"'
+      - 'export BAR="123"'
+      - 'export BAZ="1.2"'
+      - 'export QUX="foo=bar"'
       - 'export FOO_NULL="null"'
       - 'export FOO_TRUE="true"'
       - 'export FOO_FALSE="false"'
@@ -27,7 +32,9 @@ file:
     contains:
       - '# /etc/profile.d/test.sh'
       - 'export FOO="bar"'
-      - 'export BAR="baz"'
+      - 'export BAR="123"'
+      - 'export BAZ="1.2"'
+      - 'export QUX="foo=bar"'
       - 'export FOO_NULL="null"'
       - 'export FOO_TRUE="true"'
       - 'export FOO_FALSE="false"'

--- a/manala.environment/tests/0101_variables_legacy.yml
+++ b/manala.environment/tests/0101_variables_legacy.yml
@@ -11,8 +11,9 @@
         export: true
     manala_environment_variables:
       - FOO: bar
-      - BAR: foo
-      - BAR: baz
+      - BAR: 123
+      - BAZ: 1.2
+      - QUX: foo=bar
       - FOO_NULL:  null
       - FOO_TRUE:  true
       - FOO_FALSE: false
@@ -20,8 +21,8 @@
     - copy:
         dest: /etc/environment
         content: |
-          BAZ="baz"
-          FOO="foo"
+          _FOO="bar"
+          _BAR="123"
     - file:
         path: /etc/zsh
         state: directory


### PR DESCRIPTION
Fix #140 