### PR TITLE
Add yarn ohmyzsh plugin by default

### DIFF
--- a/manala.ohmyzsh/templates/users/php.dev.j2
+++ b/manala.ohmyzsh/templates/users/php.dev.j2
@@ -62,7 +62,7 @@ fi
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-{{ macros.config_row(config, 'plugins', '(git debian common-aliases history history-substring-search thefuck npm composer symfony2)') }}
+{{ macros.config_row(config, 'plugins', '(git debian common-aliases history history-substring-search thefuck npm composer symfony2, yarn)') }}
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
Because I'm tired of sending `yarn Jenkinsfile` to my terminal by mistake by hitting tab after `yarn` 😄 