### PR TITLE
Disable client_max_body_size on ssl offloading

### DIFF
--- a/manala.nginx/CHANGELOG.md
+++ b/manala.nginx/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Disable client_max_body_size on ssl offloading on dev template
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.nginx/CHANGELOG.md
+++ b/manala.nginx/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- Disable client_max_body_size on ssl offloading on dev template
+- Disable client_max_body_size on ssl offloading dev template
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.nginx/templates/configs/app_ssl_offloading.dev.j2
+++ b/manala.nginx/templates/configs/app_ssl_offloading.dev.j2
@@ -23,5 +23,6 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_pass http://127.0.0.1;
+        client_max_body_size 0;
     }
 }


### PR DESCRIPTION
Disable client_max_body_size on ssl offloading to prevent `413 Payload Too Large` errors.