### PR TITLE
[Php] Provide "cli" and "fpm" as default sapis

### DIFF
--- a/manala.php/CHANGELOG.md
+++ b/manala.php/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Provide "cli" and "fpm" as default sapis
 
 ## [1.0.7] - 2018-01-23
 ### Fixed

--- a/manala.php/defaults/main.yml
+++ b/manala.php/defaults/main.yml
@@ -5,7 +5,10 @@ manala_php_version: ~
 
 # Sapis
 manala_php_sapis_exclusive: false
-manala_php_sapis:           []
+manala_php_sapis:           ~
+manala_php_sapis_default:
+  - cli
+  - fpm
 
 # Extensions
 manala_php_extensions_exclusive: false

--- a/manala.php/handlers/main.yml
+++ b/manala.php/handlers/main.yml
@@ -5,7 +5,7 @@
   when: |
     'fpm' in lookup(
       'manala_php_sapis',
-      manala_php_sapis,
+      manala_php_sapis|default(manala_php_sapis_default, True),
       manala_php_versions[manala_php_version|string],
       wantstate='present',
       wantmap=true,
@@ -23,7 +23,7 @@
   when: |
     'fpm' in lookup(
       'manala_php_sapis',
-      manala_php_sapis,
+      manala_php_sapis|default(manala_php_sapis_default, True),
       manala_php_versions[manala_php_version|string],
       wantstate='present',
       wantmap=true,

--- a/manala.php/tasks/install.yml
+++ b/manala.php/tasks/install.yml
@@ -13,7 +13,7 @@
       (
         lookup(
           'manala_php_sapis',
-          manala_php_sapis,
+          manala_php_sapis|default(manala_php_sapis_default, True),
           manala_php_versions[manala_php_version|string],
           wantstate='present',
           wantmap=true,
@@ -47,7 +47,7 @@
       (
         lookup(
           'manala_php_sapis',
-          manala_php_sapis,
+          manala_php_sapis|default(manala_php_sapis_default, True),
           manala_php_versions[manala_php_version|string],
           wantstate='absent',
           wantmap=true,
@@ -98,7 +98,7 @@
         (
           lookup(
             'manala_php_sapis',
-            manala_php_sapis,
+            manala_php_sapis|default(manala_php_sapis_default, True),
             manala_php_versions[manala_php_version|string],
             wantstate='present',
             wantmap=true,
@@ -140,7 +140,7 @@
         (
           lookup(
             'manala_php_sapis',
-            manala_php_sapis,
+            manala_php_sapis|default(manala_php_sapis_default, True),
             manala_php_versions[manala_php_version|string],
             wantstate='present',
             wantmap=true,

--- a/manala.php/tasks/main.yml
+++ b/manala.php/tasks/main.yml
@@ -27,7 +27,7 @@
   with_items: "{{
     lookup(
       'manala_php_sapis',
-      manala_php_sapis,
+      manala_php_sapis|default(manala_php_sapis_default, True),
       manala_php_versions[manala_php_version|string],
       wantstate='present',
       wantmap=true,
@@ -44,7 +44,7 @@
   when: |
     'fpm' in lookup(
       'manala_php_sapis',
-      manala_php_sapis,
+      manala_php_sapis|default(manala_php_sapis_default, True),
       manala_php_versions[manala_php_version|string],
       wantstate='present',
       wantmap=true,

--- a/manala.php/tasks/services.yml
+++ b/manala.php/tasks/services.yml
@@ -9,7 +9,7 @@
   when: |
     'fpm' in lookup(
       'manala_php_sapis',
-      manala_php_sapis,
+      manala_php_sapis|default(manala_php_sapis_default, True),
       manala_php_versions[manala_php_version|string],
       wantstate='present',
       wantmap=true,

--- a/manala.php/tests/0400_configs_global.5.4.yml
+++ b/manala.php/tests/0400_configs_global.5.4.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_global: true
     manala_php_configs_exclusive: true
     manala_php_configs:

--- a/manala.php/tests/0501_configs.5.5.yml
+++ b/manala.php/tests/0501_configs.5.5.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_exclusive: true
     manala_php_configs:
       - file: foo.ini

--- a/manala.php/tests/0502_configs.5.6_dotdeb.yml
+++ b/manala.php/tests/0502_configs.5.6_dotdeb.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_exclusive: true
     manala_php_configs:
       - file: foo.ini

--- a/manala.php/tests/0503_configs.5.6.yml
+++ b/manala.php/tests/0503_configs.5.6.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5.6
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_exclusive: true
     manala_php_configs:
       - file: foo.ini

--- a/manala.php/tests/0504_configs.7.0_dotdeb.yml
+++ b/manala.php/tests/0504_configs.7.0_dotdeb.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.0
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_exclusive: true
     manala_php_configs:
       - file: foo.ini

--- a/manala.php/tests/0505_configs.7.0.yml
+++ b/manala.php/tests/0505_configs.7.0.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.0
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_exclusive: true
     manala_php_configs:
       - file: foo.ini

--- a/manala.php/tests/0506_configs.7.1.yml
+++ b/manala.php/tests/0506_configs.7.1.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.1
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_exclusive: true
     manala_php_configs:
       - file: foo.ini

--- a/manala.php/tests/0507_configs.7.2.yml
+++ b/manala.php/tests/0507_configs.7.2.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.2
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_configs_exclusive: true
     manala_php_configs:
       - file: foo.ini

--- a/manala.php/tests/0600_fpm_pools.5.4.yml
+++ b/manala.php/tests/0600_fpm_pools.5.4.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0601_fpm_pools.5.5.yml
+++ b/manala.php/tests/0601_fpm_pools.5.5.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
+++ b/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0603_fpm_pools.5.6.yml
+++ b/manala.php/tests/0603_fpm_pools.5.6.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5.6
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
+++ b/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.0
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0605_fpm_pools.7.0.yml
+++ b/manala.php/tests/0605_fpm_pools.7.0.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.0
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0606_fpm_pools.7.1.yml
+++ b/manala.php/tests/0606_fpm_pools.7.1.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.1
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0607_fpm_pools.7.2.yml
+++ b/manala.php/tests/0607_fpm_pools.7.2.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.2
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_fpm_pools_exclusive: true
     manala_php_fpm_pools:
       - file:     www.conf

--- a/manala.php/tests/0700_blackfire.5.4.yml
+++ b/manala.php/tests/0700_blackfire.5.4.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89

--- a/manala.php/tests/0701_blackfire.5.5.yml
+++ b/manala.php/tests/0701_blackfire.5.5.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89

--- a/manala.php/tests/0702_blackfire.5.6_dotdeb.yml
+++ b/manala.php/tests/0702_blackfire.5.6_dotdeb.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89

--- a/manala.php/tests/0703_blackfire.5.6.yml
+++ b/manala.php/tests/0703_blackfire.5.6.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 5.6
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89

--- a/manala.php/tests/0704_blackfire.7.0_dotdeb.yml
+++ b/manala.php/tests/0704_blackfire.7.0_dotdeb.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.0
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89

--- a/manala.php/tests/0705_blackfire.7.0.yml
+++ b/manala.php/tests/0705_blackfire.7.0.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.0
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89

--- a/manala.php/tests/0706_blackfire.7.1.yml
+++ b/manala.php/tests/0706_blackfire.7.1.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.1
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89

--- a/manala.php/tests/0707_blackfire.7.2.yml
+++ b/manala.php/tests/0707_blackfire.7.2.yml
@@ -5,9 +5,6 @@
   become: true
   vars:
     manala_php_version: 7.2
-    manala_php_sapis:
-      - cli
-      - fpm
     manala_php_blackfire: true
     manala_php_blackfire_agent_config:
       - server-id: c74906db-43d3-4c96-ab27-010600321b89


### PR DESCRIPTION
Just like debian do with its generic "php" package (see: https://packages.debian.org/stretch/php7.0)