### PR TITLE
[All] Replace deprecated uses of "include"

### DIFF
--- a/manala.accounts/CHANGELOG.md
+++ b/manala.accounts/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.accounts/meta/main.yml
+++ b/manala.accounts/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle accounts users and groups
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.accounts/tasks/main.yml
+++ b/manala.accounts/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Groups
-- include: groups.yml
+- import_tasks: groups.yml
   tags:
     - manala_accounts
 
 # Users
-- include: users.yml
+- import_tasks: users.yml
   tags:
     - manala_accounts

--- a/manala.alternatives/CHANGELOG.md
+++ b/manala.alternatives/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.alternatives/meta/main.yml
+++ b/manala.alternatives/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle alternatives
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.alternatives/tasks/main.yml
+++ b/manala.alternatives/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 
 # Selections
-- include: selections.yml
-  when: manala_alternatives_selections|length
+- import_tasks: selections.yml
   tags:
     - manala_alternatives

--- a/manala.ansible-galaxy/CHANGELOG.md
+++ b/manala.ansible-galaxy/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.ansible-galaxy/meta/main.yml
+++ b/manala.ansible-galaxy/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle ansible galaxy
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.ansible-galaxy/tasks/main.yml
+++ b/manala.ansible-galaxy/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Alternatives
-- include: alternatives.yml
+- import_tasks: alternatives.yml
   tags:
     - manala_ansible_galaxy
     # Ensure alternatives in update mode
@@ -9,7 +9,7 @@
     - manala.update
 
 # Roles
-- include: roles.yml
+- import_tasks: roles.yml
   tags:
     - manala_ansible_galaxy
     - manala_ansible_galaxy.update

--- a/manala.ansible/CHANGELOG.md
+++ b/manala.ansible/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Update base config template for ansible 2.5.0
+- Replace deprecated uses of "include"
 
 ## [1.0.3] - 2018-03-14
 ### Changed

--- a/manala.ansible/meta/main.yml
+++ b/manala.ansible/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle ansible
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.ansible/tasks/main.yml
+++ b/manala.ansible/tasks/main.yml
@@ -1,26 +1,26 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_ansible
 
 # Hosts
-- include: hosts.yml
+- import_tasks: hosts.yml
   tags:
     - manala_ansible
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_ansible
 
 # Host vars
-- include: host_vars.yml
+- import_tasks: host_vars.yml
   tags:
     - manala_ansible
 
 # Group vars
-- include: group_vars.yml
+- import_tasks: group_vars.yml
   tags:
     - manala_ansible

--- a/manala.ansible/tests/0100_install.yml
+++ b/manala.ansible/tests/0100_install.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ansible
         content: |

--- a/manala.ansible/tests/0200_hosts.yml
+++ b/manala.ansible/tests/0200_hosts.yml
@@ -18,9 +18,9 @@
       - bar:children:
         - foo
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ansible
         content: |

--- a/manala.ansible/tests/0300_config.yml
+++ b/manala.ansible/tests/0300_config.yml
@@ -15,9 +15,9 @@
       - foo:
           - bar: baz
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ansible
         content: |

--- a/manala.ansible/tests/0400_host_vars.yml
+++ b/manala.ansible/tests/0400_host_vars.yml
@@ -23,9 +23,9 @@
       - file: baz.yml
         state: absent
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ansible
         content: |

--- a/manala.ansible/tests/0401_host_vars_exclusive.yml
+++ b/manala.ansible/tests/0401_host_vars_exclusive.yml
@@ -10,9 +10,9 @@
       - file: bar.yml
       - file: baz.yml
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ansible
         content: |

--- a/manala.ansible/tests/0500_group_vars.yml
+++ b/manala.ansible/tests/0500_group_vars.yml
@@ -23,9 +23,9 @@
       - file: baz.yml
         state: absent
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ansible
         content: |

--- a/manala.ansible/tests/0501_group_vars_exclusive.yml
+++ b/manala.ansible/tests/0501_group_vars_exclusive.yml
@@ -10,9 +10,9 @@
       - file: bar.yml
       - file: baz.yml
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ansible
         content: |

--- a/manala.apparmor/CHANGELOG.md
+++ b/manala.apparmor/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.apparmor/meta/main.yml
+++ b/manala.apparmor/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Install and configure AppArmor
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.apparmor/tasks/main.yml
+++ b/manala.apparmor/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
 
-- include: install.yml
+# Install
+- import_tasks: install.yml
   tags:
     - manala_apparmor
 
-- include: configs.yml
+# Configs
+- import_tasks: configs.yml
   tags:
     - manala_apparmor

--- a/manala.apt/CHANGELOG.md
+++ b/manala.apt/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Update aptly key
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.17] - 2018-03-21
 ### Added

--- a/manala.apt/meta/main.yml
+++ b/manala.apt/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle apt
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.apt/tasks/main.yml
+++ b/manala.apt/tasks/main.yml
@@ -1,33 +1,32 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_apt
 
 # Sources list
-- include: sources_list.yml
-  when: (manala_apt_sources_list_template is not none) or (manala_apt_sources_list|length)
+- import_tasks: sources_list.yml
   tags:
     - manala_apt
 
 # Preferences
-- include: preferences.yml
+- import_tasks: preferences.yml
   tags:
     - manala_apt
 
 # Keys
-- include: keys.yml
+- import_tasks: keys.yml
   tags:
     - manala_apt
 
 # Repositories
-- include: repositories.yml
+- import_tasks: repositories.yml
   tags:
     - manala_apt
 
 # Update
-- include: update.yml
+- import_tasks: update.yml
   when: manala_apt['update']|default(false)
   tags:
     - manala_apt
@@ -35,6 +34,6 @@
     - manala.update
 
 # Packages
-- include: packages.yml
+- import_tasks: packages.yml
   tags:
     - manala_apt

--- a/manala.apt/tasks/sources_list.yml
+++ b/manala.apt/tasks/sources_list.yml
@@ -4,3 +4,4 @@
   template:
     src:  "{{ manala_apt_sources_list_template|ternary(manala_apt_sources_list_template, 'sources_list/empty.j2') }}"
     dest: "{{ manala_apt_sources_list_file }}"
+  when: (manala_apt_sources_list_template is not none) or (manala_apt_sources_list|length)

--- a/manala.aptly/CHANGELOG.md
+++ b/manala.aptly/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.aptly/meta/main.yml
+++ b/manala.aptly/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle aptly
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.aptly/tasks/main.yml
+++ b/manala.aptly/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_aptly
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_aptly
 
 # Repositories
-- include: repositories.yml
+- import_tasks: repositories.yml
   tags:
     - manala_aptly

--- a/manala.aptly/tests/0100_install.yml
+++ b/manala.aptly/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/aptly.yml
+    - import_tasks: pre_tasks/aptly.yml
     - copy:
         dest: /etc/apt/preferences.d/aptly
         content: |

--- a/manala.aptly/tests/0200_config.yml
+++ b/manala.aptly/tests/0200_config.yml
@@ -7,7 +7,7 @@
     manala_aptly_config:
       - rootDir: /tmp/aptly
   pre_tasks:
-    - include: pre_tasks/aptly.yml
+    - import_tasks: pre_tasks/aptly.yml
     - copy:
         dest: /etc/apt/preferences.d/aptly
         content: |

--- a/manala.aptly/tests/0300_repositories.yml
+++ b/manala.aptly/tests/0300_repositories.yml
@@ -16,7 +16,7 @@
         origin:       Bar
         label:        Bar
   pre_tasks:
-    - include: pre_tasks/aptly.yml
+    - import_tasks: pre_tasks/aptly.yml
     - copy:
         dest: /etc/apt/preferences.d/aptly
         content: |

--- a/manala.backup-manager/CHANGELOG.md
+++ b/manala.backup-manager/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.backup-manager/meta/main.yml
+++ b/manala.backup-manager/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle backup manager
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.backup-manager/tasks/main.yml
+++ b/manala.backup-manager/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_backup_manager
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_backup_manager

--- a/manala.backup-manager/tests/0100_install.yml
+++ b/manala.backup-manager/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.backup-manager
   post_tasks:

--- a/manala.backup-manager/tests/0200_configs.yml
+++ b/manala.backup-manager/tests/0200_configs.yml
@@ -10,7 +10,7 @@
         config:
           - BM_REPOSITORY_ROOT: /srv/backup/mysql
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.backup-manager
   post_tasks:

--- a/manala.beanstalkd/CHANGELOG.md
+++ b/manala.beanstalkd/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.beanstalkd/meta/main.yml
+++ b/manala.beanstalkd/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle beanstalkd
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.beanstalkd/tasks/main.yml
+++ b/manala.beanstalkd/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_beanstalkd
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_beanstalkd
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_beanstalkd
     - manala_beanstalkd.services

--- a/manala.bind/CHANGELOG.md
+++ b/manala.bind/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2018-03-16
 ### Added

--- a/manala.bind/meta/main.yml
+++ b/manala.bind/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle bind
   license:             MIT
-  min_ansible_version: 2.3.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.bind/tasks/main.yml
+++ b/manala.bind/tasks/main.yml
@@ -1,38 +1,38 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_bind
 
 # Options
-- include: options.yml
+- import_tasks: options.yml
   tags:
     - manala_bind
 
 # Logs
-- include: logs.yml
+- import_tasks: logs.yml
   tags:
     - manala_bind
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_bind
 
 # Zones
-- include: zones.yml
+- import_tasks: zones.yml
   tags:
     - manala_bind
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_bind
     - manala_bind.services
     - manala.services
 
 # Zones - Records
-- include: zones_records.yml
+- import_tasks: zones_records.yml
   tags:
     - manala_bind

--- a/manala.cloud-init/CHANGELOG.md
+++ b/manala.cloud-init/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.cloud-init/meta/main.yml
+++ b/manala.cloud-init/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Configure cloud-init
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.cloud-init/tasks/main.yml
+++ b/manala.cloud-init/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_cloud_init
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_cloud_init

--- a/manala.cloud-init/tests/0100_install.yml
+++ b/manala.cloud-init/tests/0100_install.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
   roles:
     - manala.cloud-init
   post_tasks:

--- a/manala.cloud-init/tests/0200_configs.yml
+++ b/manala.cloud-init/tests/0200_configs.yml
@@ -10,8 +10,8 @@
           - fqdn:     foo.manala.io
           - hostname: foo
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
   roles:
     - manala.cloud-init
   post_tasks:

--- a/manala.composer/CHANGELOG.md
+++ b/manala.composer/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.composer/meta/main.yml
+++ b/manala.composer/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle composer
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.composer/tasks/main.yml
+++ b/manala.composer/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_composer
 
 # Users Auth
-- include: users_auth.yml
+- import_tasks: users_auth.yml
   tags:
     - manala_composer

--- a/manala.cron/CHANGELOG.md
+++ b/manala.cron/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.cron/meta/main.yml
+++ b/manala.cron/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle cron
   license:             MIT
-  min_ansible_version: 2.1.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.cron/tasks/main.yml
+++ b/manala.cron/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_cron
 
 # Files
-- include: files.yml
+- import_tasks: files.yml
   tags:
     - manala_cron
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_cron
     - manala_cron.services

--- a/manala.dhcp/CHANGELOG.md
+++ b/manala.dhcp/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.0] - 2018-03-15
 ### Added
 - Handle installation

--- a/manala.dhcp/meta/main.yml
+++ b/manala.dhcp/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle isc dhcp server
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.dhcp/tasks/main.yml
+++ b/manala.dhcp/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_dhcp
 
 # Interfaces
-- include: interfaces.yml
+- import_tasks: interfaces.yml
   tags:
     - manala_dhcp
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_dhcp
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_dhcp
     - manala_dhcp.services

--- a/manala.dnsmasq/CHANGELOG.md
+++ b/manala.dnsmasq/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.dnsmasq/meta/main.yml
+++ b/manala.dnsmasq/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle dnsmasq
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.dnsmasq/tasks/main.yml
+++ b/manala.dnsmasq/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
 
-- include: install.yml
-- include: configs.yml
-- include: services.yml
-  tags: manala_services
+# Install
+- import_tasks: install.yml
+  tags:
+    - manala_dnsmasq
+
+# Configs
+- import_tasks: configs.yml
+  tags:
+    - manala_dnsmasq
+
+# Services
+- import_tasks: services.yml
+  tags:
+    - manala_dnsmasq
+    - manala_dnsmasq.services
+    - manala.services

--- a/manala.docker/CHANGELOG.md
+++ b/manala.docker/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.10] - 2018-02-22
 ### Added
 - Handle containers

--- a/manala.docker/meta/main.yml
+++ b/manala.docker/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle Docker
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.docker/tasks/main.yml
+++ b/manala.docker/tasks/main.yml
@@ -1,34 +1,34 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_docker
 
 # Config - Daemon
-- include: config_daemon.yml
+- import_tasks: config_daemon.yml
   tags:
     - manala_docker
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_docker
     - manala_docker.services
     - manala.services
 
 # Applications
-- include: applications.yml
+- import_tasks: applications.yml
   tags:
     - manala_docker
 
 # Containers
-- include: containers.yml
+- import_tasks: containers.yml
   tags:
     - manala_docker
 
 # Update
-- include: update.yml
+- import_tasks: update.yml
   when: manala_docker['update']|default(false)
   tags:
     - manala_docker

--- a/manala.docker/tests/0100_install.yml
+++ b/manala.docker/tests/0100_install.yml
@@ -7,8 +7,8 @@
     manala_docker_config_daemon:
       - storage-driver: vfs
   pre_tasks:
-    - include: pre_tasks/docker.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/docker.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'wheezy'
   roles:
     - manala.docker

--- a/manala.docker/tests/0200_config_daemon.yml
+++ b/manala.docker/tests/0200_config_daemon.yml
@@ -8,8 +8,8 @@
       - storage-driver: vfs
       - experimental: false
   pre_tasks:
-    - include: pre_tasks/docker.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/docker.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'wheezy'
   roles:
     - manala.docker

--- a/manala.docker/tests/0300_services.yml
+++ b/manala.docker/tests/0300_services.yml
@@ -7,8 +7,8 @@
     manala_docker_config_daemon:
       - storage-driver: vfs
   pre_tasks:
-    - include: pre_tasks/docker.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/docker.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'wheezy'
   roles:
     - manala.docker

--- a/manala.docker/tests/0400_applications.yml
+++ b/manala.docker/tests/0400_applications.yml
@@ -13,8 +13,8 @@
         command:     npm
         tag:         alpine
   pre_tasks:
-    - include: pre_tasks/docker.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/docker.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'wheezy'
   roles:
     - manala.docker

--- a/manala.docker/tests/0500_containers.yml
+++ b/manala.docker/tests/0500_containers.yml
@@ -10,7 +10,7 @@
       - name: hello-world
         image: hello-world
   pre_tasks:
-    - include: pre_tasks/docker.yml
+    - import_tasks: pre_tasks/docker.yml
   roles:
     - manala.docker
   post_tasks:

--- a/manala.docker/tests/0600_update.yml
+++ b/manala.docker/tests/0600_update.yml
@@ -9,8 +9,8 @@
     manala_docker:
       update: true
   pre_tasks:
-    - include: pre_tasks/docker.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/docker.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'wheezy'
   roles:
     - manala.docker

--- a/manala.elasticsearch/CHANGELOG.md
+++ b/manala.elasticsearch/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Replace deprecated jinja tests used as filters
 - Add curl to pretty in Goss tests to check installed version
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.elasticsearch/meta/main.yml
+++ b/manala.elasticsearch/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle elasticsearch
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.elasticsearch/tasks/main.yml
+++ b/manala.elasticsearch/tasks/main.yml
@@ -1,28 +1,28 @@
 ---
 
 # Requirements
-- include: requirements.yml
+- import_tasks: requirements.yml
   tags:
     - manala_elasticsearch
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_elasticsearch
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_elasticsearch
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_elasticsearch
     - manala_elasticsearch.services
     - manala.services
 
 # Plugins
-- include: plugins.yml
+- import_tasks: plugins.yml
   tags:
     - manala_elasticsearch

--- a/manala.elasticsearch/tests/0200_install.1.5.yml
+++ b/manala.elasticsearch/tests/0200_install.1.5.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.5.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.5.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -22,6 +22,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0201_install.1.6.yml
+++ b/manala.elasticsearch/tests/0201_install.1.6.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.6.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.6.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -22,6 +22,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0202_install.1.7.yml
+++ b/manala.elasticsearch/tests/0202_install.1.7.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.7.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.7.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -22,6 +22,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0203_install.2.yml
+++ b/manala.elasticsearch/tests/0203_install.2.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/elasticsearch_2.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_2.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -22,6 +22,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0204_install.5.yml
+++ b/manala.elasticsearch/tests/0204_install.5.yml
@@ -4,8 +4,8 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/elasticsearch_5.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_5.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -22,6 +22,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0205_install.6.yml
+++ b/manala.elasticsearch/tests/0205_install.6.yml
@@ -4,8 +4,8 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/elasticsearch_6.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_6.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -22,6 +22,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0300_config.1.5.yml
+++ b/manala.elasticsearch/tests/0300_config.1.5.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_config:
       - node.name: Foo Bar
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.5.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.5.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0301_config.1.6.yml
+++ b/manala.elasticsearch/tests/0301_config.1.6.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_config:
       - node.name: Foo Bar
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.6.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.6.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0302_config.1.7.yml
+++ b/manala.elasticsearch/tests/0302_config.1.7.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_config:
       - node.name: Foo Bar
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.7.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.7.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0303_config.2.yml
+++ b/manala.elasticsearch/tests/0303_config.2.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_config:
       - node.name: Foo Bar
   pre_tasks:
-    - include: pre_tasks/elasticsearch_2.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_2.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0304_config.5.yml
+++ b/manala.elasticsearch/tests/0304_config.5.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_config:
       - node.name: Foo Bar
   pre_tasks:
-    - include: pre_tasks/elasticsearch_5.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_5.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0305_config.6.yml
+++ b/manala.elasticsearch/tests/0305_config.6.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_config:
       - node.name: Foo Bar
   pre_tasks:
-    - include: pre_tasks/elasticsearch_6.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_6.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0500_plugins.1.5.yml
+++ b/manala.elasticsearch/tests/0500_plugins.1.5.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_plugins:
       - mobz/elasticsearch-head
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.5.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.5.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0501_plugins.1.6.yml
+++ b/manala.elasticsearch/tests/0501_plugins.1.6.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_plugins:
       - mobz/elasticsearch-head
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.6.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.6.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0502_plugins.1.7.yml
+++ b/manala.elasticsearch/tests/0502_plugins.1.7.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_plugins:
       - mobz/elasticsearch-head
   pre_tasks:
-    - include: pre_tasks/elasticsearch_1.7.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_1.7.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.elasticsearch/tests/0503_plugins.2.yml
+++ b/manala.elasticsearch/tests/0503_plugins.2.yml
@@ -7,8 +7,8 @@
     manala_elasticsearch_plugins:
       - mobz/elasticsearch-head
   pre_tasks:
-    - include: pre_tasks/elasticsearch_2.yml
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/elasticsearch_2.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
     - copy:
         dest: /etc/apt/preferences.d/openjdk
@@ -25,6 +25,6 @@
   roles:
     - manala.elasticsearch
   post_tasks:
-    - include: post_tasks/pretty_response.yml
+    - import_tasks: post_tasks/pretty_response.yml
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.environment/CHANGELOG.md
+++ b/manala.environment/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.3] - 2018-01-23
 ### Fixed

--- a/manala.environment/meta/main.yml
+++ b/manala.environment/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle environment variables
   license:             MIT
-  min_ansible_version: 2.1.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.environment/tasks/main.yml
+++ b/manala.environment/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 
 # Variables
-- include: variables.yml
-  with_manala_environment_files:
-    - "{{ manala_environment_files }}"
-    - "{{ manala_environment_files_patterns }}"
-  loop_control:
-    loop_var: item_file
+- import_tasks: variables.yml
   tags:
     - manala_environment

--- a/manala.environment/tasks/variables.yml
+++ b/manala.environment/tasks/variables.yml
@@ -2,8 +2,11 @@
 
 - name: variables > File
   blockinfile:
-    dest:  "{{ item_file.file }}"
+    dest:  "{{ item.file }}"
     block: |
       {% for variable in lookup('manala_environment_variables', manala_environment_variables, wantlist=True) %}
-      {{ (item_file.export)|ternary('export ', '') }}{{ variable.name }}="{{ variable.value }}"
+      {{ (item.export)|ternary('export ', '') }}{{ variable.name }}="{{ variable.value }}"
       {% endfor %}
+  with_manala_environment_files:
+    - "{{ manala_environment_files }}"
+    - "{{ manala_environment_files_patterns }}"

--- a/manala.fail2ban/CHANGELOG.md
+++ b/manala.fail2ban/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.fail2ban/meta/main.yml
+++ b/manala.fail2ban/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle fail2ban
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.fail2ban/tasks/main.yml
+++ b/manala.fail2ban/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_fail2ban
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_fail2ban
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_fail2ban
     - manala_fail2ban.services

--- a/manala.files/CHANGELOG.md
+++ b/manala.files/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.files/meta/main.yml
+++ b/manala.files/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle files attributes
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.files/tasks/attributes.yml
+++ b/manala.files/tasks/attributes.yml
@@ -1,0 +1,7 @@
+---
+
+- name: attributes
+  include_tasks: attributes/{{ item['task'] }}.yml
+  with_manala_files_attributes:
+    - "{{ manala_files_attributes }}"
+    - "{{ manala_files_attributes_defaults }}"

--- a/manala.files/tasks/attributes/content.yml
+++ b/manala.files/tasks/attributes/content.yml
@@ -1,10 +1,15 @@
 ---
 
-- name: attributes > Content "{{ item.path }}"
-  copy:
-    dest:    "{{ item.path }}"
-    content: "{{ item.content }}"
-    force:   "{{ item.force|default(omit) }}"
-    owner:   "{{ item.user|default(omit) }}"
-    group:   "{{ item.group|default(omit) }}"
-    mode:    "{{ item.mode|default(omit) }}"
+- name: attributes/content
+  tags:
+    - manala_files
+  block:
+
+    - name: attributes/content > Copy "{{ item.path }}"
+      copy:
+        dest:    "{{ item.path }}"
+        content: "{{ item.content }}"
+        force:   "{{ item.force|default(omit) }}"
+        owner:   "{{ item.user|default(omit) }}"
+        group:   "{{ item.group|default(omit) }}"
+        mode:    "{{ item.mode|default(omit) }}"

--- a/manala.files/tasks/attributes/copy.yml
+++ b/manala.files/tasks/attributes/copy.yml
@@ -1,10 +1,15 @@
 ---
 
-- name: attributes > Copy "{{ item.path }}"
-  copy:
-    dest:    "{{ item.path }}"
-    src:     "{{ item['copy'] }}"
-    force:   "{{ item.force|default(omit) }}"
-    owner:   "{{ item.user|default(omit) }}"
-    group:   "{{ item.group|default(omit) }}"
-    mode:    "{{ item.mode|default(omit) }}"
+- name: attributes/copy
+  tags:
+    - manala_files
+  block:
+
+    - name: attributes/copy > Copy "{{ item.path }}"
+      copy:
+        dest:    "{{ item.path }}"
+        src:     "{{ item['copy'] }}"
+        force:   "{{ item.force|default(omit) }}"
+        owner:   "{{ item.user|default(omit) }}"
+        group:   "{{ item.group|default(omit) }}"
+        mode:    "{{ item.mode|default(omit) }}"

--- a/manala.files/tasks/attributes/file.yml
+++ b/manala.files/tasks/attributes/file.yml
@@ -1,13 +1,18 @@
 ---
 
-- name: attributes > File "{{ item.path }}"
-  file:
-    path:    "{{ item.path }}"
-    follow:  "{{ item.follow|default(omit) }}"
-    recurse: "{{ item.recurse|default(omit) }}"
-    src:     "{{ item.src|default(omit) }}"
-    force:   "{{ item.force|default(omit) }}"
-    owner:   "{{ item.user|default(omit) }}"
-    group:   "{{ item.group|default(omit) }}"
-    mode:    "{{ item.mode|default(omit) }}"
-    state:   "{{ item.state|default(omit) }}"
+- name: attributes/file
+  tags:
+    - manala_files
+  block:
+
+    - name: attributes/file > File "{{ item.path }}"
+      file:
+        path:    "{{ item.path }}"
+        follow:  "{{ item.follow|default(omit) }}"
+        recurse: "{{ item.recurse|default(omit) }}"
+        src:     "{{ item.src|default(omit) }}"
+        force:   "{{ item.force|default(omit) }}"
+        owner:   "{{ item.user|default(omit) }}"
+        group:   "{{ item.group|default(omit) }}"
+        mode:    "{{ item.mode|default(omit) }}"
+        state:   "{{ item.state|default(omit) }}"

--- a/manala.files/tasks/attributes/link_file.yml
+++ b/manala.files/tasks/attributes/link_file.yml
@@ -1,24 +1,29 @@
 ---
 
-- name: attributes > Link file - Src file "{{ item.src }}"
-  file:
-    path:    "{{ item.src }}"
-    follow:  "{{ item.follow|default(omit) }}"
-    recurse: "{{ item.recurse|default(omit) }}"
-    force:   "{{ item.force|default(omit) }}"
-    owner:   "{{ item.user|default(omit) }}"
-    group:   "{{ item.group|default(omit) }}"
-    mode:    "{{ item.mode|default(omit) }}"
-    state:   touch
+- name: attributes/link_file
+  tags:
+    - manala_files
+  block:
 
-- name: attributes > Link file - Path link "{{ item.path }}"
-  file:
-    path:    "{{ item.path }}"
-    follow:  "{{ item.follow|default(omit) }}"
-    recurse: "{{ item.recurse|default(omit) }}"
-    src:     "{{ item.src|default(omit) }}"
-    force:   "{{ item.mode|default(omit) }}"
-    owner:   "{{ item.user|default(omit) }}"
-    group:   "{{ item.group|default(omit) }}"
-    mode:    "{{ item.mode|default(omit) }}"
-    state:   link
+    - name: attributes/link_file > File "{{ item.src }}"
+      file:
+        path:    "{{ item.src }}"
+        follow:  "{{ item.follow|default(omit) }}"
+        recurse: "{{ item.recurse|default(omit) }}"
+        force:   "{{ item.force|default(omit) }}"
+        owner:   "{{ item.user|default(omit) }}"
+        group:   "{{ item.group|default(omit) }}"
+        mode:    "{{ item.mode|default(omit) }}"
+        state:   touch
+
+    - name: attributes/link_file > Link "{{ item.path }}"
+      file:
+        path:    "{{ item.path }}"
+        follow:  "{{ item.follow|default(omit) }}"
+        recurse: "{{ item.recurse|default(omit) }}"
+        src:     "{{ item.src|default(omit) }}"
+        force:   "{{ item.mode|default(omit) }}"
+        owner:   "{{ item.user|default(omit) }}"
+        group:   "{{ item.group|default(omit) }}"
+        mode:    "{{ item.mode|default(omit) }}"
+        state:   link

--- a/manala.files/tasks/attributes/template.yml
+++ b/manala.files/tasks/attributes/template.yml
@@ -1,10 +1,15 @@
 ---
 
-- name: attributes > Template "{{ item.path }}"
-  template:
-    dest:   "{{ item.path }}"
-    src:    "{{ item.template }}"
-    force:  "{{ item.force|default(omit) }}"
-    owner:   "{{ item.user|default(omit) }}"
-    group:   "{{ item.group|default(omit) }}"
-    mode:   "{{ item.mode|default(omit) }}"
+- name: attributes/template
+  tags:
+    - manala_files
+  block:
+
+    - name: attributes/template > Template "{{ item.path }}"
+      template:
+        dest:   "{{ item.path }}"
+        src:    "{{ item.template }}"
+        force:  "{{ item.force|default(omit) }}"
+        owner:   "{{ item.user|default(omit) }}"
+        group:   "{{ item.group|default(omit) }}"
+        mode:   "{{ item.mode|default(omit) }}"

--- a/manala.files/tasks/attributes/url.yml
+++ b/manala.files/tasks/attributes/url.yml
@@ -1,11 +1,16 @@
 ---
 
-- name: files > Url "{{ item.path }}"
-  get_url:
-    dest:           "{{ item.path }}"
-    url:            "{{ item.url }}"
-    validate_certs: "{{ item.validate_certs|default(true)|bool }}"
-    force:          "{{ item.force|default(omit) }}"
-    owner:          "{{ item.user|default(omit) }}"
-    group:          "{{ item.group|default(omit) }}"
-    mode:           "{{ item.mode|default(omit) }}"
+- name: attributes/url
+  tags:
+    - manala_files
+  block:
+
+    - name: attributes/url > Get "{{ item.path }}"
+      get_url:
+        dest:           "{{ item.path }}"
+        url:            "{{ item.url }}"
+        validate_certs: "{{ item.validate_certs|default(true)|bool }}"
+        force:          "{{ item.force|default(omit) }}"
+        owner:          "{{ item.user|default(omit) }}"
+        group:          "{{ item.group|default(omit) }}"
+        mode:           "{{ item.mode|default(omit) }}"

--- a/manala.files/tasks/main.yml
+++ b/manala.files/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
 
 # Attributes
-- include: attributes/{{ item['task'] }}.yml
-  with_manala_files_attributes:
-    - "{{ manala_files_attributes }}"
-    - "{{ manala_files_attributes_defaults }}"
+- import_tasks: attributes.yml
   tags:
     - manala_files

--- a/manala.git/CHANGELOG.md
+++ b/manala.git/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.git/meta/main.yml
+++ b/manala.git/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   company:             Manala
   description:         Handle git
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.git/tasks/main.yml
+++ b/manala.git/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_git
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_git
 
 # Repositories
-- include: repositories.yml
+- import_tasks: repositories.yml
   tags:
     - manala_git

--- a/manala.git/tests/0100_install.yml
+++ b/manala.git/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
   roles:
     - manala.git
   post_tasks:

--- a/manala.git/tests/0200_config.yml
+++ b/manala.git/tests/0200_config.yml
@@ -8,7 +8,7 @@
       - core:
         - preloadindex: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
   roles:
     - manala.git
   post_tasks:

--- a/manala.git/tests/0300_repositories.yml
+++ b/manala.git/tests/0300_repositories.yml
@@ -11,7 +11,7 @@
         dest: /tmp/ansible-role-git-user
         user: manala
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
   roles:
     - manala.git
   post_tasks:

--- a/manala.gitlab/CHANGELOG.md
+++ b/manala.gitlab/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.gitlab/meta/main.yml
+++ b/manala.gitlab/meta/main.yml
@@ -6,10 +6,9 @@ galaxy_info:
 
   author:              Manala
   company:             Manala
-  description: >
-    Setup and config gitlab-ce
+  description:         Handle gitlab
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:
@@ -18,6 +17,4 @@ galaxy_info:
         - stretch
   categories:
     - development
-    - web
     - git
-    - system

--- a/manala.gitlab/tasks/main.yml
+++ b/manala.gitlab/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
 
-- include: install.yml
+# Install
+- import_tasks: install.yml
   tags:
     - manala_gitlab
-- include: configs.yml
+
+# Configs
+- import_tasks: configs.yml
   tags:
     - manala_gitlab

--- a/manala.gitlab/tests/0100_install.yml
+++ b/manala.gitlab/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/gitlab.yml
+    - import_tasks: pre_tasks/gitlab.yml
   roles:
     - manala.gitlab
   post_tasks:

--- a/manala.grafana/CHANGELOG.md
+++ b/manala.grafana/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Fix missings ansible 2.1 deprecation "Supplying headers via HEADER_* is deprecated"
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.grafana/meta/main.yml
+++ b/manala.grafana/meta/main.yml
@@ -6,9 +6,9 @@ galaxy_info:
 
   author:              Manala
   company:             Manala
-  description:         Install and configure grafana.
+  description:         Handle grafana
   license:             MIT
-  min_ansible_version: 2.1.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.grafana/tasks/main.yml
+++ b/manala.grafana/tasks/main.yml
@@ -1,30 +1,30 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_grafana
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_grafana
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_grafana
     - manala_grafana.services
     - manala.services
 
 # Datasources
-- include: datasources.yml
-  when: manala_grafana_datasources|length > 0 or manala_grafana_datasources_exclusive
+- import_tasks: datasources.yml
+  when: manala_grafana_datasources|length or manala_grafana_datasources_exclusive
   tags:
     - manala_grafana
 
 # Dashboards
-- include: dashboards.yml
-  when: manala_grafana_dashboards|length > 0 or manala_grafana_dashboards_exclusive
+- import_tasks: dashboards.yml
+  when: manala_grafana_dashboards|length or manala_grafana_dashboards_exclusive
   tags:
     - manala_grafana

--- a/manala.grafana/tests/0100_install.yml
+++ b/manala.grafana/tests/0100_install.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/grafana.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/grafana.yml
   roles:
    - manala.grafana
   post_tasks:

--- a/manala.grafana/tests/0200_install.yml
+++ b/manala.grafana/tests/0200_install.yml
@@ -8,8 +8,8 @@
       - server:
         - http_port: 3002
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/grafana.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/grafana.yml
   roles:
    - manala.grafana
   post_tasks:

--- a/manala.grafana/tests/0300_services.yml
+++ b/manala.grafana/tests/0300_services.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/grafana.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/grafana.yml
   roles:
    - manala.grafana
   post_tasks:

--- a/manala.grafana/tests/0400_datasources.yml
+++ b/manala.grafana/tests/0400_datasources.yml
@@ -22,8 +22,8 @@
         username:  ''
         password:  ''
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/grafana.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/grafana.yml
   roles:
     - manala.grafana
   post_tasks:

--- a/manala.grafana/tests/0500_dashboards.yml
+++ b/manala.grafana/tests/0500_dashboards.yml
@@ -15,8 +15,8 @@
       - template: "{{ playbook_dir }}/templates/dashboard_test.json"
         overwrite: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/grafana.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/grafana.yml
   roles:
     - manala.grafana
   post_tasks:

--- a/manala.haproxy/CHANGELOG.md
+++ b/manala.haproxy/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2018-03-28
 ### Changed
 - Replace handlers "haproxy restart"/"do haproxy restart" by a single "haproxy reload",

--- a/manala.haproxy/meta/main.yml
+++ b/manala.haproxy/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle haproxy
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.haproxy/tasks/main.yml
+++ b/manala.haproxy/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_haproxy
 
 # Errorfiles
-- include: errorfiles.yml
+- import_tasks: errorfiles.yml
   tags:
     - manala_haproxy
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_haproxy
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_haproxy
     - manala_haproxy.services

--- a/manala.haproxy/tests/0100_install.yml
+++ b/manala.haproxy/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
   roles:
     - manala.haproxy
   post_tasks:

--- a/manala.haproxy/tests/0200_errorfiles.yml
+++ b/manala.haproxy/tests/0200_errorfiles.yml
@@ -8,7 +8,7 @@
       - file: 400.http
         template: fixtures/400.http.j2
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
   roles:
     - manala.haproxy
   post_tasks:

--- a/manala.haproxy/tests/0300_config.yml
+++ b/manala.haproxy/tests/0300_config.yml
@@ -6,7 +6,7 @@
   vars:
     manala_haproxy_config_template: fixtures/haproxy.cfg.j2
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
   roles:
     - manala.haproxy
   post_tasks:

--- a/manala.haproxy/tests/0400_services.yml
+++ b/manala.haproxy/tests/0400_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
   roles:
     - manala.haproxy
   post_tasks:

--- a/manala.heka/CHANGELOG.md
+++ b/manala.heka/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.heka/meta/main.yml
+++ b/manala.heka/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle heka
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.heka/tasks/main.yml
+++ b/manala.heka/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_heka
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_heka
 
 # Config
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_heka
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_heka
     - manala_heka.services

--- a/manala.heka/tests/0100_install.yml
+++ b/manala.heka/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/heka
         content: |

--- a/manala.heka/tests/0400_services.yml
+++ b/manala.heka/tests/0400_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/heka
         content: |

--- a/manala.hugo/CHANGELOG.md
+++ b/manala.hugo/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.hugo/meta/main.yml
+++ b/manala.hugo/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle Hugo
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.hugo/tasks/main.yml
+++ b/manala.hugo/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_hugo

--- a/manala.hugo/tests/0100_install.yml
+++ b/manala.hugo/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/hugo
         content: |

--- a/manala.influxdb/CHANGELOG.md
+++ b/manala.influxdb/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2018-03-12
 ### Changed
 - Update config template for 1.5.0

--- a/manala.influxdb/meta/main.yml
+++ b/manala.influxdb/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Install and configure InfluxDB
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.influxdb/tasks/main.yml
+++ b/manala.influxdb/tasks/main.yml
@@ -1,33 +1,33 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_influxdb
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_influxdb
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_influxdb
     - manala_influxdb.services
     - manala.services
 
 # Databases
-- include: databases.yml
+- import_tasks: databases.yml
   tags:
     - manala_influxdb
 
 # Users
-- include: users.yml
+- import_tasks: users.yml
   tags:
     - manala_influxdb
 
 # Privileges
-- include: privileges.yml
+- import_tasks: privileges.yml
   tags:
     - manala_influxdb

--- a/manala.influxdb/tests/0100_install.yml
+++ b/manala.influxdb/tests/0100_install.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.influxdb
   post_tasks:

--- a/manala.influxdb/tests/0200_config.yml
+++ b/manala.influxdb/tests/0200_config.yml
@@ -7,8 +7,8 @@
     manala_influxdb_config:
       - reporting-disabled: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.influxdb
   post_tasks:

--- a/manala.influxdb/tests/0300_services.yml
+++ b/manala.influxdb/tests/0300_services.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.influxdb
   post_tasks:

--- a/manala.influxdb/tests/0400_databases.yml
+++ b/manala.influxdb/tests/0400_databases.yml
@@ -7,8 +7,8 @@
     manala_influxdb_databases:
       - my_db
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.influxdb
   post_tasks:

--- a/manala.influxdb/tests/0500_users.yml
+++ b/manala.influxdb/tests/0500_users.yml
@@ -11,8 +11,8 @@
         name:     my_user
         password: my_password
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.influxdb
   post_tasks:

--- a/manala.influxdb/tests/0600_privileges.yml
+++ b/manala.influxdb/tests/0600_privileges.yml
@@ -15,8 +15,8 @@
         user:     my_user
         grant:    ALL
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.influxdb
   post_tasks:

--- a/manala.java/CHANGELOG.md
+++ b/manala.java/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.java/meta/main.yml
+++ b/manala.java/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle java
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.java/tasks/main.yml
+++ b/manala.java/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Requirements
-- include: requirements.yml
+- import_tasks: requirements.yml
   tags:
     - manala_java
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_java

--- a/manala.java/tests/0102_install.8.yml
+++ b/manala.java/tests/0102_install.8.yml
@@ -6,7 +6,7 @@
   vars:
     manala_java_version: 8
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
       when: ansible_distribution_release == 'jessie'
   roles:
     - manala.java

--- a/manala.keepalived/CHANGELOG.md
+++ b/manala.keepalived/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Configure keepalived environment file

--- a/manala.keepalived/meta/main.yml
+++ b/manala.keepalived/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle keepalived
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.keepalived/tasks/main.yml
+++ b/manala.keepalived/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_keepalived
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_keepalived
 
 # Environment
-- include: environment.yml
+- import_tasks: environment.yml
   tags:
     - manala_keepalived
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_keepalived
     - manala_keepalived.services

--- a/manala.keepalived/tests/0100_install.yml
+++ b/manala.keepalived/tests/0100_install.yml
@@ -4,8 +4,8 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.keepalived
   post_tasks:

--- a/manala.keepalived/tests/0200_config.yml
+++ b/manala.keepalived/tests/0200_config.yml
@@ -16,8 +16,8 @@
           - 192.168.200.11/24 dev eth0
           - 192.168.200.12/24 dev eth0
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.keepalived
   post_tasks:

--- a/manala.keepalived/tests/0300_services.yml
+++ b/manala.keepalived/tests/0300_services.yml
@@ -8,8 +8,8 @@
       - global_defs:
         - router_id: LVS_DEVEL
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.keepalived
   post_tasks:

--- a/manala.keepalived/tests/0400_environment.yml
+++ b/manala.keepalived/tests/0400_environment.yml
@@ -7,8 +7,8 @@
     manala_keepalived_environment:
       - DAEMON_ARGS: --log-console --log-detail
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.keepalived
   post_tasks:

--- a/manala.kernel/CHANGELOG.md
+++ b/manala.kernel/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.kernel/meta/main.yml
+++ b/manala.kernel/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle kernel modules and parameters
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.kernel/tasks/main.yml
+++ b/manala.kernel/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Modules
-- include: modules.yml
+- import_tasks: modules.yml
   tags:
     - manala_kernel
 
 # Parameters
-- include: parameters.yml
+- import_tasks: parameters.yml
   tags:
     - manala_kernel

--- a/manala.locales/CHANGELOG.md
+++ b/manala.locales/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.locales/meta/main.yml
+++ b/manala.locales/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle locales
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.locales/tasks/debian/main.yml
+++ b/manala.locales/tasks/debian/main.yml
@@ -1,12 +1,12 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
 
 # Codes
-- include: codes.yml
+- import_tasks: codes.yml
   when: manala_locales_codes|length
 
 # Codes Defaults
-- include: codes_default.yml
+- import_tasks: codes_default.yml
   when: manala_locales_codes_default is not none

--- a/manala.locales/tasks/main.yml
+++ b/manala.locales/tasks/main.yml
@@ -6,14 +6,12 @@
   tags:
      - manala_locales
 
-- name: main > Include "Debian" tasks
-  include: debian/main.yml
+- import_tasks: debian/main.yml
   when: ansible_os_family == 'Debian'
   tags:
      - manala_locales
 
-- name: main > Include "RedHat" tasks
-  include: redhat/main.yml
+- import_tasks: redhat/main.yml
   when: ansible_os_family == 'RedHat'
   tags:
      - manala_locales

--- a/manala.locales/tasks/redhat/main.yml
+++ b/manala.locales/tasks/redhat/main.yml
@@ -1,12 +1,12 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
 
 # Codes
-- include: codes.yml
+- import_tasks: codes.yml
   when: manala_locales_codes|length
 
 # Codes Defaults
-- include: codes_default.yml
+- import_tasks: codes_default.yml
   when: manala_locales_codes_default is not none

--- a/manala.logentries/CHANGELOG.md
+++ b/manala.logentries/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.0] - 2017-06-09
 ### Added
 - Handle installation

--- a/manala.logentries/meta/main.yml
+++ b/manala.logentries/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle locales
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.logentries/tasks/main.yml
+++ b/manala.logentries/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_logentries
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_logentries
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_logentries
     - manala_logentries.services

--- a/manala.logentries/tests/0100_install.yml
+++ b/manala.logentries/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/logentries.yml
+    - import_tasks: pre_tasks/logentries.yml
     - copy:
         dest: /etc/apt/preferences.d/logentries
         content: |

--- a/manala.logentries/tests/0200_config.yml
+++ b/manala.logentries/tests/0200_config.yml
@@ -9,7 +9,7 @@
         - pull-server-side-config: false
         - user-key: e720a1e8-a7d5-4f8b-8879-854e51c9290d
   pre_tasks:
-    - include: pre_tasks/logentries.yml
+    - import_tasks: pre_tasks/logentries.yml
     - copy:
         dest: /etc/apt/preferences.d/logentries
         content: |

--- a/manala.logentries/tests/0300_services.yml
+++ b/manala.logentries/tests/0300_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/logentries.yml
+    - import_tasks: pre_tasks/logentries.yml
     - copy:
         dest: /etc/apt/preferences.d/logentries
         content: |

--- a/manala.logrotate/CHANGELOG.md
+++ b/manala.logrotate/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.logrotate/meta/main.yml
+++ b/manala.logrotate/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle logrotate
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.logrotate/tasks/main.yml
+++ b/manala.logrotate/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_logrotate
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_logrotate

--- a/manala.mailhog/CHANGELOG.md
+++ b/manala.mailhog/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.mailhog/meta/main.yml
+++ b/manala.mailhog/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle mailhog
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.mailhog/tasks/main.yml
+++ b/manala.mailhog/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_mailhog
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_mailhog
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_mailhog
     - manala_mailhog.services

--- a/manala.mailhog/tests/0100_install.yml
+++ b/manala.mailhog/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/mailhog
         content: |

--- a/manala.mailhog/tests/0200_config.yml
+++ b/manala.mailhog/tests/0200_config.yml
@@ -7,7 +7,7 @@
     manala_mailhog_config:
       - smtp-bind-addr: 1.2.3.4:2525
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/mailhog
         content: |

--- a/manala.mailhog/tests/0300_services.yml
+++ b/manala.mailhog/tests/0300_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/mailhog
         content: |

--- a/manala.make/CHANGELOG.md
+++ b/manala.make/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.make/meta/main.yml
+++ b/manala.make/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle make
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.make/tasks/main.yml
+++ b/manala.make/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_make

--- a/manala.maxscale/CHANGELOG.md
+++ b/manala.maxscale/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.maxscale/meta/main.yml
+++ b/manala.maxscale/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Installation and configuration of Maxscale (MySQL/MariaDB Proxy)
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.maxscale/tasks/main.yml
+++ b/manala.maxscale/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_maxscale
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_maxscale
 
 # Users
-- include: users.yml
+- import_tasks: users.yml
   tags:
     - manala_maxscale
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_maxscale

--- a/manala.maxscale/tests/0100_install.2.0.4.yml
+++ b/manala.maxscale/tests/0100_install.2.0.4.yml
@@ -6,9 +6,9 @@
     - debian.jessie
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.0.4.yml
+    - import_tasks: pre_tasks/maxscale_2.0.4.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.maxscale/tests/0101_install.2.1.10.yml
+++ b/manala.maxscale/tests/0101_install.2.1.10.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.1.10.yml
+    - import_tasks: pre_tasks/maxscale_2.1.10.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.maxscale/tests/0200_config.2.0.4.yml
+++ b/manala.maxscale/tests/0200_config.2.0.4.yml
@@ -16,9 +16,9 @@
         - user:    maxscale
         - passwd:  XXXXXXXXXXXX
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.0.4.yml
+    - import_tasks: pre_tasks/maxscale_2.0.4.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.maxscale/tests/0201_config.2.1.10.yml
+++ b/manala.maxscale/tests/0201_config.2.1.10.yml
@@ -14,9 +14,9 @@
         - user:    maxscale
         - passwd:  XXXXXXXXXXXX
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.1.10.yml
+    - import_tasks: pre_tasks/maxscale_2.1.10.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.maxscale/tests/0300_users.2.0.4.yml
+++ b/manala.maxscale/tests/0300_users.2.0.4.yml
@@ -13,9 +13,9 @@
       - name:     maxscale-admin
         password: $1$MXS$aTODkN/QXQSexlaH1dRdA0
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.0.4.yml
+    - import_tasks: pre_tasks/maxscale_2.0.4.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.maxscale/tests/0301_users.2.1.10.yml
+++ b/manala.maxscale/tests/0301_users.2.1.10.yml
@@ -11,9 +11,9 @@
       - name:     maxscale-admin
         password: $1$MXS$aTODkN/QXQSexlaH1dRdA0
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.1.10.yml
+    - import_tasks: pre_tasks/maxscale_2.1.10.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.maxscale/tests/0400_services.2.0.4.yml
+++ b/manala.maxscale/tests/0400_services.2.0.4.yml
@@ -6,9 +6,9 @@
     - debian.jessie
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.0.4.yml
+    - import_tasks: pre_tasks/maxscale_2.0.4.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.maxscale/tests/0401_services.2.1.10.yml
+++ b/manala.maxscale/tests/0401_services.2.1.10.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
       when: ansible_distribution_release == 'jessie'
-    - include: pre_tasks/maxscale_2.1.10.yml
+    - import_tasks: pre_tasks/maxscale_2.1.10.yml
   roles:
     - manala.maxscale
   post_tasks:

--- a/manala.merge/CHANGELOG.md
+++ b/manala.merge/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.merge/meta/main.yml
+++ b/manala.merge/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle merge
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.merge/tasks/hashes.yml
+++ b/manala.merge/tasks/hashes.yml
@@ -5,3 +5,4 @@
     hash:   "{{ lookup('manala_merge', item.hashes, wantlist=true) }}"
     prefix: "{{ item.prefix|default(omit) }}"
     var:    "{{ item.var|default(omit) }}"
+  with_items: "{{ manala_merge_hashes }}"

--- a/manala.merge/tasks/main.yml
+++ b/manala.merge/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
 
-- include: hashes.yml
-  with_items: "{{ manala_merge_hashes }}"
+# Hashes
+- import_tasks: hashes.yml
+  tags:
+    - manala_merge

--- a/manala.mongo-express/CHANGELOG.md
+++ b/manala.mongo-express/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.mongo-express/meta/main.yml
+++ b/manala.mongo-express/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle mongo express
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.mongo-express/tasks/main.yml
+++ b/manala.mongo-express/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_mongo_express
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_mongo_express
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_mongo_express
     - manala_mongo_express.services

--- a/manala.mongo-express/tests/0100_install.yml
+++ b/manala.mongo-express/tests/0100_install.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/mongo-express
         content: |

--- a/manala.mongo-express/tests/0200_config.yml
+++ b/manala.mongo-express/tests/0200_config.yml
@@ -6,9 +6,9 @@
   vars:
     manala_mongo_express_config_template: config/default.dev.j2
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/mongo-express
         content: |

--- a/manala.mongo-express/tests/0300_services.yml
+++ b/manala.mongo-express/tests/0300_services.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/mongo-express
         content: |

--- a/manala.mongodb/CHANGELOG.md
+++ b/manala.mongodb/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.mongodb/meta/main.yml
+++ b/manala.mongodb/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle mongodb
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.mongodb/tasks/main.yml
+++ b/manala.mongodb/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_mongodb
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_mongodb
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_mongodb
     - manala_mongodb.services

--- a/manala.mongodb/tests/0100_install.yml
+++ b/manala.mongodb/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/mongodb_3_2.yml
+    - import_tasks: pre_tasks/mongodb_3_2.yml
     - copy:
         dest: /etc/apt/preferences.d/mongodb
         content: |

--- a/manala.mongodb/tests/0200_config.yml
+++ b/manala.mongodb/tests/0200_config.yml
@@ -7,7 +7,7 @@
     manala_mongodb_config:
       - port: 12345
   pre_tasks:
-    - include: pre_tasks/mongodb_3_2.yml
+    - import_tasks: pre_tasks/mongodb_3_2.yml
     - copy:
         dest: /etc/apt/preferences.d/mongodb
         content: |

--- a/manala.mongodb/tests/0300_services.yml
+++ b/manala.mongodb/tests/0300_services.yml
@@ -4,7 +4,7 @@
   hosts: debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/mongodb_3_2.yml
+    - import_tasks: pre_tasks/mongodb_3_2.yml
     - copy:
         dest: /etc/apt/preferences.d/mongodb
         content: |

--- a/manala.motd/CHANGELOG.md
+++ b/manala.motd/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.motd/meta/main.yml
+++ b/manala.motd/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle motd
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.motd/tasks/main.yml
+++ b/manala.motd/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Template
-- include: template.yml
+- import_tasks: template.yml
   tags:
     - manala_motd

--- a/manala.mount/CHANGELOG.md
+++ b/manala.mount/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.mount/meta/main.yml
+++ b/manala.mount/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle mount
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.mount/tasks/main.yml
+++ b/manala.mount/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Points
-- include: points.yml
+- import_tasks: points.yml
   tags:
     - manala_mount

--- a/manala.mysql/CHANGELOG.md
+++ b/manala.mysql/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Handle default dependency packages to install
 - Handle replications
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.3] - 2018-03-28
 ### Changed
 - Allow passing configs variables as boolean

--- a/manala.mysql/meta/main.yml
+++ b/manala.mysql/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle mysql
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.mysql/tasks/main.yml
+++ b/manala.mysql/tasks/main.yml
@@ -1,33 +1,33 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_mysql
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_mysql
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_mysql
     - manala_mysql.services
     - manala.services
 
 # Users
-- include: users.yml
+- import_tasks: users.yml
   tags:
     - manala_mysql
 
 # Databases
-- include: databases.yml
+- import_tasks: databases.yml
   tags:
     - manala_mysql
 
 # Replications
-- include: replications.yml
+- import_tasks: replications.yml
   tags:
     - manala_mysql

--- a/manala.mysql/tests/0100_install.5.6.yml
+++ b/manala.mysql/tests/0100_install.5.6.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/mysql_5.6.yml
+    - import_tasks: pre_tasks/mysql_5.6.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0101_install.5.7.yml
+++ b/manala.mysql/tests/0101_install.5.7.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/mysql_5.7.yml
+    - import_tasks: pre_tasks/mysql_5.7.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0110_install.galera.3.mysql_wsrep.5.6.yml
+++ b/manala.mysql/tests/0110_install.galera.3.mysql_wsrep.5.6.yml
@@ -10,8 +10,8 @@
       - mysql-wsrep-server-5.6
       - mysql-wsrep-client-5.6
   pre_tasks:
-    - include: pre_tasks/galera_3.yml
-    - include: pre_tasks/mysql_wsrep_5.6.yml
+    - import_tasks: pre_tasks/galera_3.yml
+    - import_tasks: pre_tasks/mysql_wsrep_5.6.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0111_install.galera.3.mysql_wsrep.5.7.yml
+++ b/manala.mysql/tests/0111_install.galera.3.mysql_wsrep.5.7.yml
@@ -11,8 +11,8 @@
       - mysql-wsrep-server-5.7
       - mysql-wsrep-client-5.7
   pre_tasks:
-    - include: pre_tasks/galera_3.yml
-    - include: pre_tasks/mysql_wsrep_5.7.yml
+    - import_tasks: pre_tasks/galera_3.yml
+    - import_tasks: pre_tasks/mysql_wsrep_5.7.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0120_install.mariadb.10.0.yml
+++ b/manala.mysql/tests/0120_install.mariadb.10.0.yml
@@ -10,7 +10,7 @@
       - mariadb-server
       - mariadb-client
   pre_tasks:
-    - include: pre_tasks/mariadb_10.0.yml
+    - import_tasks: pre_tasks/mariadb_10.0.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0121_install.mariadb.10.1.yml
+++ b/manala.mysql/tests/0121_install.mariadb.10.1.yml
@@ -8,7 +8,7 @@
       - mariadb-server
       - mariadb-client
   pre_tasks:
-    - include: pre_tasks/mariadb_10.1.yml
+    - import_tasks: pre_tasks/mariadb_10.1.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0122_install.mariadb.10.2.yml
+++ b/manala.mysql/tests/0122_install.mariadb.10.2.yml
@@ -8,7 +8,7 @@
       - mariadb-server
       - mariadb-client
   pre_tasks:
-    - include: pre_tasks/mariadb_10.2.yml
+    - import_tasks: pre_tasks/mariadb_10.2.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0200_configs.5.6.yml
+++ b/manala.mysql/tests/0200_configs.5.6.yml
@@ -13,7 +13,7 @@
             - gtid_mode:                true
             - enforce_gtid_consistency: false
   pre_tasks:
-    - include: pre_tasks/mysql_5.6.yml
+    - import_tasks: pre_tasks/mysql_5.6.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0201_configs_exclusive.5.6.yml
+++ b/manala.mysql/tests/0201_configs_exclusive.5.6.yml
@@ -19,7 +19,7 @@
             - innodb_log_buffer_size:  256M
             - innodb_buffer_pool_size: 3G
   pre_tasks:
-    - include: pre_tasks/mysql_5.6.yml
+    - import_tasks: pre_tasks/mysql_5.6.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0300_user.5.6.yml
+++ b/manala.mysql/tests/0300_user.5.6.yml
@@ -10,7 +10,7 @@
         host:     "localhost"
         priv:     "*.*:ALL,GRANT"
   pre_tasks:
-    - include: pre_tasks/mysql_5.6.yml
+    - import_tasks: pre_tasks/mysql_5.6.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0301_user.5.7.yml
+++ b/manala.mysql/tests/0301_user.5.7.yml
@@ -10,7 +10,7 @@
         host:     "localhost"
         priv:     "*.*:ALL,GRANT"
   pre_tasks:
-    - include: pre_tasks/mysql_5.7.yml
+    - import_tasks: pre_tasks/mysql_5.7.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0400_databases.5.6.yml
+++ b/manala.mysql/tests/0400_databases.5.6.yml
@@ -8,7 +8,7 @@
       - name: manala_test_1
       - name: manala_test_2
   pre_tasks:
-    - include: pre_tasks/mysql_5.6.yml
+    - import_tasks: pre_tasks/mysql_5.6.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.mysql/tests/0401_databases.5.7.yml
+++ b/manala.mysql/tests/0401_databases.5.7.yml
@@ -8,7 +8,7 @@
       - name: manala_test_1
       - name: manala_test_2
   pre_tasks:
-    - include: pre_tasks/mysql_5.7.yml
+    - import_tasks: pre_tasks/mysql_5.7.yml
   roles:
     - manala.mysql
   post_tasks:

--- a/manala.network/CHANGELOG.md
+++ b/manala.network/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Debian stretch support
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-10-04
 ### Changed
 - Use unsafe_writes when updating /etc/hosts to work around some situations

--- a/manala.network/meta/main.yml
+++ b/manala.network/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle network hosts, resolver and interfaces
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.network/tasks/main.yml
+++ b/manala.network/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 # Hosts
-- include: hosts.yml
+- import_tasks: hosts.yml
   tags:
     - manala_network
 
 # Resolver
-- include: resolver.yml
+- import_tasks: resolver.yml
   tags:
     - manala_network
 
 # Inerfaces
-- include: interfaces.yml
+- import_tasks: interfaces.yml
   tags:
     - manala_network

--- a/manala.nginx/CHANGELOG.md
+++ b/manala.nginx/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2018-03-01
 ### Changed
 - Disable client_max_body_size on ssl offloading dev template

--- a/manala.nginx/meta/main.yml
+++ b/manala.nginx/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle nginx
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.nginx/tasks/main.yml
+++ b/manala.nginx/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_nginx
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_nginx
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_nginx
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_nginx
     - manala_nginx.services

--- a/manala.nginx/tests/0100_install.yml
+++ b/manala.nginx/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/nginx.yml
+    - import_tasks: pre_tasks/nginx.yml
   roles:
     - manala.nginx
   post_tasks:

--- a/manala.nginx/tests/0200_config.yml
+++ b/manala.nginx/tests/0200_config.yml
@@ -9,7 +9,7 @@
       - events:
         - worker_connections: 1234
   pre_tasks:
-    - include: pre_tasks/nginx.yml
+    - import_tasks: pre_tasks/nginx.yml
   roles:
     - manala.nginx
   post_tasks:

--- a/manala.nginx/tests/0300_configs.yml
+++ b/manala.nginx/tests/0300_configs.yml
@@ -13,7 +13,7 @@
             - location /:
               - root:  /srv/foo
   pre_tasks:
-    - include: pre_tasks/nginx.yml
+    - import_tasks: pre_tasks/nginx.yml
   roles:
     - manala.nginx
   post_tasks:

--- a/manala.nginx/tests/0400_services.yml
+++ b/manala.nginx/tests/0400_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/nginx.yml
+    - import_tasks: pre_tasks/nginx.yml
   roles:
     - manala.nginx
   post_tasks:

--- a/manala.ngrok/CHANGELOG.md
+++ b/manala.ngrok/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.ngrok/meta/main.yml
+++ b/manala.ngrok/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle ngrok
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.ngrok/tasks/main.yml
+++ b/manala.ngrok/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
 
-- include: install.yml
+# Install
+- import_tasks: install.yml
   tags:
     - manala_ngrok
 
-- include: configs.yml
+# Configs
+- import_tasks: configs.yml
   tags:
     - manala_ngrok

--- a/manala.ngrok/tests/0100_install.yml
+++ b/manala.ngrok/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ngrok
         content: |

--- a/manala.ngrok/tests/0200_configs.yml
+++ b/manala.ngrok/tests/0200_configs.yml
@@ -9,7 +9,7 @@
         config:
           - web_addr: 1.2.3.4:1234
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/ngrok
         content: |

--- a/manala.nodejs/CHANGELOG.md
+++ b/manala.nodejs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.3] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.nodejs/meta/main.yml
+++ b/manala.nodejs/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle nodejs
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.nodejs/tasks/main.yml
+++ b/manala.nodejs/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_nodejs

--- a/manala.nodejs/tests/0100_install.0.10.yml
+++ b/manala.nodejs/tests/0100_install.0.10.yml
@@ -6,7 +6,7 @@
     - debian.jessie
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_0_10.yml
+    - import_tasks: pre_tasks/nodesource_0_10.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.nodejs/tests/0101_install.0.12.yml
+++ b/manala.nodejs/tests/0101_install.0.12.yml
@@ -6,7 +6,7 @@
     - debian.jessie
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_0_12.yml
+    - import_tasks: pre_tasks/nodesource_0_12.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.nodejs/tests/0102_install.4.yml
+++ b/manala.nodejs/tests/0102_install.4.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_4.yml
+    - import_tasks: pre_tasks/nodesource_4.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.nodejs/tests/0103_install.5.yml
+++ b/manala.nodejs/tests/0103_install.5.yml
@@ -6,7 +6,7 @@
     - debian.jessie
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_5.yml
+    - import_tasks: pre_tasks/nodesource_5.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.nodejs/tests/0104_install.6.yml
+++ b/manala.nodejs/tests/0104_install.6.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_6.yml
+    - import_tasks: pre_tasks/nodesource_6.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.nodejs/tests/0105_install.7.yml
+++ b/manala.nodejs/tests/0105_install.7.yml
@@ -4,7 +4,7 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_7.yml
+    - import_tasks: pre_tasks/nodesource_7.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.nodejs/tests/0106_install.8.yml
+++ b/manala.nodejs/tests/0106_install.8.yml
@@ -4,7 +4,7 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_8.yml
+    - import_tasks: pre_tasks/nodesource_8.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.nodejs/tests/0107_install.9.yml
+++ b/manala.nodejs/tests/0107_install.9.yml
@@ -4,7 +4,7 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/nodesource_9.yml
+    - import_tasks: pre_tasks/nodesource_9.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.npm/CHANGELOG.md
+++ b/manala.npm/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.npm/meta/main.yml
+++ b/manala.npm/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle npm
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.npm/tasks/main.yml
+++ b/manala.npm/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
 # Requirements
-- include: requirements.yml
+- import_tasks: requirements.yml
   tags:
     - manala_npm
 
 # Update
-- include: update.yml
+- import_tasks: update.yml
   when: manala_npm['update']|default(false)
   tags:
     - manala_npm
@@ -14,6 +14,6 @@
     - manala.update
 
 # Packages
-- include: packages.yml
+- import_tasks: packages.yml
   tags:
     - manala_npm

--- a/manala.npm/tests/0100_packages.yml
+++ b/manala.npm/tests/0100_packages.yml
@@ -12,7 +12,7 @@
       - package: negative-zero
         state: present
   pre_tasks:
-    - include: pre_tasks/nodesource_6.yml
+    - import_tasks: pre_tasks/nodesource_6.yml
     - copy:
         dest: /etc/apt/preferences.d/nodejs
         content: |

--- a/manala.ntp/CHANGELOG.md
+++ b/manala.ntp/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.ntp/meta/main.yml
+++ b/manala.ntp/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle ntp
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.ntp/tasks/main.yml
+++ b/manala.ntp/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
      - manala_ntp
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
      - manala_ntp
      - manala_ntp.services

--- a/manala.oauth2-proxy/CHANGELOG.md
+++ b/manala.oauth2-proxy/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.oauth2-proxy/meta/main.yml
+++ b/manala.oauth2-proxy/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle oauth2-proxy
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.oauth2-proxy/tasks/main.yml
+++ b/manala.oauth2-proxy/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_oauth2_proxy
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_oauth2_proxy
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_oauth2_proxy
     - manala_oauth2_proxy.services

--- a/manala.oauth2-proxy/tests/0100_install.yml
+++ b/manala.oauth2-proxy/tests/0100_install.yml
@@ -12,7 +12,7 @@
       - client_secret: bar
       - cookie_secret: bar
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.oauth2-proxy
   post_tasks:

--- a/manala.oauth2-proxy/tests/0200_config.yml
+++ b/manala.oauth2-proxy/tests/0200_config.yml
@@ -13,7 +13,7 @@
       - cookie_secret: bar
       - http_address: 127.0.0.1:1234
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.oauth2-proxy
   post_tasks:

--- a/manala.oauth2-proxy/tests/0300_services.yml
+++ b/manala.oauth2-proxy/tests/0300_services.yml
@@ -12,7 +12,7 @@
       - client_secret: bar
       - cookie_secret: bar
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.oauth2-proxy
   post_tasks:

--- a/manala.ohmyzsh/CHANGELOG.md
+++ b/manala.ohmyzsh/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Replace deprecated jinja tests used as filters
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.5] - 2018-01-31
 ### Added
 - Yarn plugin in php users template

--- a/manala.ohmyzsh/meta/main.yml
+++ b/manala.ohmyzsh/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle oh-my-zsh
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.ohmyzsh/tasks/main.yml
+++ b/manala.ohmyzsh/tasks/main.yml
@@ -1,20 +1,20 @@
 ---
 # Requirements
-- include: requirements.yml
+- import_tasks: requirements.yml
   tags:
     - manala_ohmyzsh
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_ohmyzsh
 
 # Themes
-- include: themes.yml
+- import_tasks: themes.yml
   tags:
     - manala_ohmyzsh
 
 # Users
-- include: users.yml
+- import_tasks: users.yml
   tags:
     - manala_ohmyzsh

--- a/manala.opcache-dashboard/CHANGELOG.md
+++ b/manala.opcache-dashboard/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-08
 ### Added
 - PHP 7.2 support

--- a/manala.opcache-dashboard/meta/main.yml
+++ b/manala.opcache-dashboard/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle opcache-dashboard
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.opcache-dashboard/tasks/main.yml
+++ b/manala.opcache-dashboard/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_opcache_dashboard

--- a/manala.opcache-dashboard/tests/0100_install.php_5.6.yml
+++ b/manala.opcache-dashboard/tests/0100_install.php_5.6.yml
@@ -4,16 +4,16 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
       when: ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.opcache-dashboard
   post_tasks:

--- a/manala.opcache-dashboard/tests/0101_install.php_7.2.yml
+++ b/manala.opcache-dashboard/tests/0101_install.php_7.2.yml
@@ -4,13 +4,13 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - php7.2-fpm
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.opcache-dashboard
   post_tasks:

--- a/manala.pam-ssh-agent-auth/CHANGELOG.md
+++ b/manala.pam-ssh-agent-auth/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.pam-ssh-agent-auth/meta/main.yml
+++ b/manala.pam-ssh-agent-auth/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle pam ssh agent auth
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.pam-ssh-agent-auth/tasks/main.yml
+++ b/manala.pam-ssh-agent-auth/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 # Requirements
-- include: requirements.yml
+- import_tasks: requirements.yml
   tags:
     - manala_pam_ssh_agent_auth
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_pam_ssh_agent_auth
 
 # Sudo
-- include: sudo.yml
+- import_tasks: sudo.yml
   tags:
     - manala_pam_ssh_agent_auth

--- a/manala.pam-ssh-agent-auth/tests/0100_install.yml
+++ b/manala.pam-ssh-agent-auth/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/pam-ssh-agent-auth
         content: |

--- a/manala.pam-ssh-agent-auth/tests/0200_sudo.yml
+++ b/manala.pam-ssh-agent-auth/tests/0200_sudo.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/pam-ssh-agent-auth
         content: |

--- a/manala.phantomjs/CHANGELOG.md
+++ b/manala.phantomjs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.phantomjs/meta/main.yml
+++ b/manala.phantomjs/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle phantomjs
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.phantomjs/tasks/main.yml
+++ b/manala.phantomjs/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_phantomjs
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_phantomjs
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_phantomjs
     - manala_phantomjs.services

--- a/manala.phantomjs/tests/0100_install.yml
+++ b/manala.phantomjs/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/phantomjs
         content: |

--- a/manala.phantomjs/tests/0200_config.yml
+++ b/manala.phantomjs/tests/0200_config.yml
@@ -7,7 +7,7 @@
     manala_phantomjs_config:
       - webdriver: 1234
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/phantomjs
         content: |

--- a/manala.phantomjs/tests/0300_services.yml
+++ b/manala.phantomjs/tests/0300_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/phantomjs
         content: |

--- a/manala.php/tasks/main.yml
+++ b/manala.php/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Requirements
-- include: requirements.yml
+- import_tasks: requirements.yml
   tags:
     - manala_php
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_php
 
 # Extensions
-- include: extensions.yml
+- import_tasks: extensions.yml
   tags:
     - manala_php
 
 # Configs - Global
-- include: configs_global.yml
+- import_tasks: configs_global.yml
   when: manala_php_configs_global
   tags:
     - manala_php
@@ -40,7 +40,7 @@
     - manala_php
 
 # Fpm pools
-- include: fpm_pools.yml
+- import_tasks: fpm_pools.yml
   when: |
     'fpm' in lookup(
       'manala_php_sapis',
@@ -54,19 +54,19 @@
     - manala_php
 
 # Blackfire
-- include: blackfire.yml
+- import_tasks: blackfire.yml
   when: manala_php_blackfire
   tags:
     - manala_php
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_php
     - manala_php.services
     - manala.services
 
 # Applications
-- include: applications.yml
+- import_tasks: applications.yml
   tags:
     - manala_php

--- a/manala.php/tests/0200_install.5.4.yml
+++ b/manala.php/tests/0200_install.5.4.yml
@@ -27,7 +27,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0201_install.5.5.yml
+++ b/manala.php/tests/0201_install.5.5.yml
@@ -27,7 +27,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0202_install.5.6_dotdeb.yml
+++ b/manala.php/tests/0202_install.5.6_dotdeb.yml
@@ -27,7 +27,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0203_install.5.6.yml
+++ b/manala.php/tests/0203_install.5.6.yml
@@ -26,7 +26,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0204_install.7.0_dotdeb.yml
+++ b/manala.php/tests/0204_install.7.0_dotdeb.yml
@@ -27,7 +27,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0205_install.7.0.yml
+++ b/manala.php/tests/0205_install.7.0.yml
@@ -27,7 +27,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0206_install.7.1.yml
+++ b/manala.php/tests/0206_install.7.1.yml
@@ -26,7 +26,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0207_install.7.2.yml
+++ b/manala.php/tests/0207_install.7.2.yml
@@ -26,7 +26,7 @@
       - extension: apcu
         state:     absent
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0210_install_exclusive.5.4.yml
+++ b/manala.php/tests/0210_install_exclusive.5.4.yml
@@ -21,7 +21,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0211_install_exclusive.5.5.yml
+++ b/manala.php/tests/0211_install_exclusive.5.5.yml
@@ -21,7 +21,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0212_install_exclusive.5.6_dotdeb.yml
+++ b/manala.php/tests/0212_install_exclusive.5.6_dotdeb.yml
@@ -21,7 +21,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0213_install_exclusive.5.6.yml
+++ b/manala.php/tests/0213_install_exclusive.5.6.yml
@@ -21,7 +21,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0214_install_exclusive.7.0_dotdeb.yml
+++ b/manala.php/tests/0214_install_exclusive.7.0_dotdeb.yml
@@ -21,7 +21,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0215_install_exclusive.7.0.yml
+++ b/manala.php/tests/0215_install_exclusive.7.0.yml
@@ -21,7 +21,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0216_install_exclusive.7.1.yml
+++ b/manala.php/tests/0216_install_exclusive.7.1.yml
@@ -20,7 +20,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0217_install_exclusive.7.2.yml
+++ b/manala.php/tests/0217_install_exclusive.7.2.yml
@@ -20,7 +20,7 @@
       - extension: curl
         state:     present
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0300_extensions.5.4.yml
+++ b/manala.php/tests/0300_extensions.5.4.yml
@@ -26,7 +26,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0301_extensions.5.5.yml
+++ b/manala.php/tests/0301_extensions.5.5.yml
@@ -26,7 +26,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0302_extensions.5.6_dotdeb.yml
+++ b/manala.php/tests/0302_extensions.5.6_dotdeb.yml
@@ -26,7 +26,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0303_extensions.5.6.yml
+++ b/manala.php/tests/0303_extensions.5.6.yml
@@ -25,7 +25,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0304_extensions.7.0_dotdeb.yml
+++ b/manala.php/tests/0304_extensions.7.0_dotdeb.yml
@@ -26,7 +26,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0305_extensions.7.0.yml
+++ b/manala.php/tests/0305_extensions.7.0.yml
@@ -26,7 +26,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0306_extensions.7.1.yml
+++ b/manala.php/tests/0306_extensions.7.1.yml
@@ -25,7 +25,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0307_extensions.7.2.yml
+++ b/manala.php/tests/0307_extensions.7.2.yml
@@ -25,7 +25,7 @@
       - extension: xdebug
         enabled:   false
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0400_configs_global.5.4.yml
+++ b/manala.php/tests/0400_configs_global.5.4.yml
@@ -19,7 +19,7 @@
         config:
           - memory_limit: 256M
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0501_configs.5.5.yml
+++ b/manala.php/tests/0501_configs.5.5.yml
@@ -28,7 +28,7 @@
         config:
           - memory_limit: 257M
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0502_configs.5.6_dotdeb.yml
+++ b/manala.php/tests/0502_configs.5.6_dotdeb.yml
@@ -28,7 +28,7 @@
         config:
           - memory_limit: 257M
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0503_configs.5.6.yml
+++ b/manala.php/tests/0503_configs.5.6.yml
@@ -28,7 +28,7 @@
         config:
           - memory_limit: 257M
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0504_configs.7.0_dotdeb.yml
+++ b/manala.php/tests/0504_configs.7.0_dotdeb.yml
@@ -28,7 +28,7 @@
         config:
           - memory_limit: 257M
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0505_configs.7.0.yml
+++ b/manala.php/tests/0505_configs.7.0.yml
@@ -28,7 +28,7 @@
         config:
           - memory_limit: 257M
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0506_configs.7.1.yml
+++ b/manala.php/tests/0506_configs.7.1.yml
@@ -28,7 +28,7 @@
         config:
           - memory_limit: 257M
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0507_configs.7.2.yml
+++ b/manala.php/tests/0507_configs.7.2.yml
@@ -28,7 +28,7 @@
         config:
           - memory_limit: 257M
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0600_fpm_pools.5.4.yml
+++ b/manala.php/tests/0600_fpm_pools.5.4.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0601_fpm_pools.5.5.yml
+++ b/manala.php/tests/0601_fpm_pools.5.5.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
+++ b/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0603_fpm_pools.5.6.yml
+++ b/manala.php/tests/0603_fpm_pools.5.6.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
+++ b/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0605_fpm_pools.7.0.yml
+++ b/manala.php/tests/0605_fpm_pools.7.0.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0606_fpm_pools.7.1.yml
+++ b/manala.php/tests/0606_fpm_pools.7.1.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0607_fpm_pools.7.2.yml
+++ b/manala.php/tests/0607_fpm_pools.7.2.yml
@@ -25,7 +25,7 @@
                 BAZ: 1.2
                 QUX: foo=bar
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false

--- a/manala.php/tests/0700_blackfire.5.4.yml
+++ b/manala.php/tests/0700_blackfire.5.4.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0701_blackfire.5.5.yml
+++ b/manala.php/tests/0701_blackfire.5.5.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0702_blackfire.5.6_dotdeb.yml
+++ b/manala.php/tests/0702_blackfire.5.6_dotdeb.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0703_blackfire.5.6.yml
+++ b/manala.php/tests/0703_blackfire.5.6.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0704_blackfire.7.0_dotdeb.yml
+++ b/manala.php/tests/0704_blackfire.7.0_dotdeb.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0705_blackfire.7.0.yml
+++ b/manala.php/tests/0705_blackfire.7.0.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0706_blackfire.7.1.yml
+++ b/manala.php/tests/0706_blackfire.7.1.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0707_blackfire.7.2.yml
+++ b/manala.php/tests/0707_blackfire.7.2.yml
@@ -13,8 +13,8 @@
       - client-id: b7bf7d2d-c8c1-4354-82bf-aa403afbc3b3
       - client-token: e7d9ca7e486b67d1f2d9b764fb383340fbd374e20daefa747e8a4fd690d83e7b
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
-    - include: pre_tasks/blackfire.yml
+    - import_tasks: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/blackfire.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0800_services.5.4.yml
+++ b/manala.php/tests/0800_services.5.4.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0801_services.5.5.yml
+++ b/manala.php/tests/0801_services.5.5.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0802_services.5.6_dotdeb.yml
+++ b/manala.php/tests/0802_services.5.6_dotdeb.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0803_services.5.6.yml
+++ b/manala.php/tests/0803_services.5.6.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0804_services.7.0_dotdeb.yml
+++ b/manala.php/tests/0804_services.7.0_dotdeb.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0805_services.7.0.yml
+++ b/manala.php/tests/0805_services.7.0.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0806_services.7.1.yml
+++ b/manala.php/tests/0806_services.7.1.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0807_services.7.2.yml
+++ b/manala.php/tests/0807_services.7.2.yml
@@ -8,7 +8,7 @@
     manala_php_sapis:
       - fpm
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0900_applications.5.4.yml
+++ b/manala.php/tests/0900_applications.5.4.yml
@@ -16,7 +16,7 @@
       - application: phpunit
         version: 4.8.31
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0901_applications.5.5.yml
+++ b/manala.php/tests/0901_applications.5.5.yml
@@ -16,7 +16,7 @@
       - application: phpunit
         version: 4.8.31
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_55.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0902_applications.5.6_dotdeb.yml
+++ b/manala.php/tests/0902_applications.5.6_dotdeb.yml
@@ -16,7 +16,7 @@
       - application: phpunit
         version: 4.8.31
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0903_applications.5.6.yml
+++ b/manala.php/tests/0903_applications.5.6.yml
@@ -15,7 +15,7 @@
       - application: phpunit
         version: 4.8.31
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0904_applications.7.0_dotdeb.yml
+++ b/manala.php/tests/0904_applications.7.0_dotdeb.yml
@@ -16,7 +16,7 @@
       - application: phpunit
         version: 4.8.31
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0905_applications.7.0.yml
+++ b/manala.php/tests/0905_applications.7.0.yml
@@ -16,7 +16,7 @@
       - application: phpunit
         version: 4.8.31
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0906_applications.7.1.yml
+++ b/manala.php/tests/0906_applications.7.1.yml
@@ -15,7 +15,7 @@
       - application: phpunit
         version: 4.8.31
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0907_applications.7.2.yml
+++ b/manala.php/tests/0907_applications.7.2.yml
@@ -15,7 +15,7 @@
       - application: phpunit
         version: 5.7.25
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
   roles:
     - manala.php
   post_tasks:

--- a/manala.phpmyadmin/CHANGELOG.md
+++ b/manala.phpmyadmin/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-08
 ### Added
 - PHP 7.2 support

--- a/manala.phpmyadmin/meta/main.yml
+++ b/manala.phpmyadmin/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle phpmyadmin
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.phpmyadmin/tasks/main.yml
+++ b/manala.phpmyadmin/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_phpmyadmin
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_phpmyadmin

--- a/manala.phpmyadmin/tests/0100_install.php_5.6.yml
+++ b/manala.phpmyadmin/tests/0100_install.php_5.6.yml
@@ -4,16 +4,16 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
       when: ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin
   post_tasks:

--- a/manala.phpmyadmin/tests/0101_install.php_7.2.yml
+++ b/manala.phpmyadmin/tests/0101_install.php_7.2.yml
@@ -4,13 +4,13 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - php7.2-fpm
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin
   post_tasks:

--- a/manala.phpmyadmin/tests/0200_configs.php_5.6.yml
+++ b/manala.phpmyadmin/tests/0200_configs.php_5.6.yml
@@ -14,16 +14,16 @@
             config:
               - host: mysql
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
       when: ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin
   post_tasks:

--- a/manala.phpmyadmin/tests/0201_configs.php_7.2.yml
+++ b/manala.phpmyadmin/tests/0201_configs.php_7.2.yml
@@ -14,13 +14,13 @@
             config:
               - host: mysql
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - php7.2-fpm
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin
   post_tasks:

--- a/manala.phppgadmin/CHANGELOG.md
+++ b/manala.phppgadmin/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-08
 ### Added
 - PHP 7.2 support

--- a/manala.phppgadmin/meta/main.yml
+++ b/manala.phppgadmin/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle phppgadmin
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.phppgadmin/tasks/main.yml
+++ b/manala.phppgadmin/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_phppgadmin
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_phppgadmin

--- a/manala.phppgadmin/tests/0100_install.php_5.6.yml
+++ b/manala.phppgadmin/tests/0100_install.php_5.6.yml
@@ -4,16 +4,16 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
       when: ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin
   post_tasks:

--- a/manala.phppgadmin/tests/0101_install.php_7.2.yml
+++ b/manala.phppgadmin/tests/0101_install.php_7.2.yml
@@ -4,13 +4,13 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - php7.2-fpm
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin
   post_tasks:

--- a/manala.phppgadmin/tests/0200_configs.php_5.6.yml
+++ b/manala.phppgadmin/tests/0200_configs.php_5.6.yml
@@ -14,16 +14,16 @@
             config:
               - host: postgresql
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
       when: ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin
   post_tasks:

--- a/manala.phppgadmin/tests/0201_configs.php_7.2.yml
+++ b/manala.phppgadmin/tests/0201_configs.php_7.2.yml
@@ -14,13 +14,13 @@
             config:
               - host: postgresql
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - php7.2-fpm
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin
   post_tasks:

--- a/manala.phpredisadmin/CHANGELOG.md
+++ b/manala.phpredisadmin/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.3] - 2017-12-08
 ### Added
 - PHP 7.2 support

--- a/manala.phpredisadmin/meta/main.yml
+++ b/manala.phpredisadmin/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle phpredisadmin
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.phpredisadmin/tasks/main.yml
+++ b/manala.phpredisadmin/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
 
-- include: install.yml
-- include: configs.yml
+# Install
+- import_tasks: install.yml
+  tags:
+    - manala_phpredisadmin
+
+# Configs
+- import_tasks: configs.yml
+  tags:
+    - manala_phpredisadmin

--- a/manala.phpredisadmin/tests/0100_install.php_5.6.yml
+++ b/manala.phpredisadmin/tests/0100_install.php_5.6.yml
@@ -4,16 +4,16 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
       when: ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin
   post_tasks:

--- a/manala.phpredisadmin/tests/0101_install.php_7.2.yml
+++ b/manala.phpredisadmin/tests/0101_install.php_7.2.yml
@@ -4,13 +4,13 @@
   hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - php7.2-fpm
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin
   post_tasks:

--- a/manala.phpredisadmin/tests/0200_configs.php_5.6.yml
+++ b/manala.phpredisadmin/tests/0200_configs.php_5.6.yml
@@ -13,16 +13,16 @@
           - config:
               - host: redis
   pre_tasks:
-    - include: pre_tasks/dotdeb_wheezy_56.yml
+    - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
       when: ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin
   post_tasks:

--- a/manala.phpredisadmin/tests/0201_configs.php_7.2.yml
+++ b/manala.phpredisadmin/tests/0201_configs.php_7.2.yml
@@ -13,13 +13,13 @@
           - config:
               - host: redis
   pre_tasks:
-    - include: pre_tasks/sury_php.yml
+    - import_tasks: pre_tasks/sury_php.yml
     - apt:
         package: "{{ item }}"
         install_recommends: false
       with_items:
         - php7.2-fpm
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin
   post_tasks:

--- a/manala.postgresql/CHANGELOG.md
+++ b/manala.postgresql/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.postgresql/meta/main.yml
+++ b/manala.postgresql/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle postgresql
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.postgresql/tasks/main.yml
+++ b/manala.postgresql/tasks/main.yml
@@ -1,38 +1,38 @@
 ---
 
 # Requirements
-- include: requirements.yml
+- import_tasks: requirements.yml
   tags:
     - manala_postgresql
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_postgresql
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_postgresql
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_postgresql
     - manala_postgresql.services
     - manala.services
 
 # Roles
-- include: roles.yml
+- import_tasks: roles.yml
   tags:
     - manala_postgresql
 
 # Databases
-- include: databases.yml
+- import_tasks: databases.yml
   tags:
     - manala_postgresql
 
 # Privileges
-- include: privileges.yml
+- import_tasks: privileges.yml
   tags:
     - manala_postgresql

--- a/manala.postgresql/tests/0100_install.yml
+++ b/manala.postgresql/tests/0100_install.yml
@@ -6,7 +6,7 @@
   vars:
     manala_postgresql_version: 9.4
   pre_tasks:
-    - include: pre_tasks/postgresql.yml
+    - import_tasks: pre_tasks/postgresql.yml
   roles:
     - manala.postgresql
   post_tasks:

--- a/manala.postgresql/tests/0200_config.yml
+++ b/manala.postgresql/tests/0200_config.yml
@@ -16,7 +16,7 @@
       - host    all             all             ::1/128                 md5
       - local   foo             bar                                     peer
   pre_tasks:
-    - include: pre_tasks/postgresql.yml
+    - import_tasks: pre_tasks/postgresql.yml
   roles:
     - manala.postgresql
   post_tasks:

--- a/manala.postgresql/tests/0300_services.yml
+++ b/manala.postgresql/tests/0300_services.yml
@@ -6,7 +6,7 @@
   vars:
     manala_postgresql_version: 9.4
   pre_tasks:
-    - include: pre_tasks/postgresql.yml
+    - import_tasks: pre_tasks/postgresql.yml
   roles:
     - manala.postgresql
   post_tasks:

--- a/manala.postgresql/tests/0400_roles.yml
+++ b/manala.postgresql/tests/0400_roles.yml
@@ -12,7 +12,7 @@
         password:   ~
         attributes: ['SUPERUSER']
   pre_tasks:
-    - include: pre_tasks/postgresql.yml
+    - import_tasks: pre_tasks/postgresql.yml
   roles:
     - manala.postgresql
   post_tasks:

--- a/manala.postgresql/tests/0500_databases.yml
+++ b/manala.postgresql/tests/0500_databases.yml
@@ -10,7 +10,7 @@
     manala_postgresql_databases:
       - database: bar
   pre_tasks:
-    - include: pre_tasks/postgresql.yml
+    - import_tasks: pre_tasks/postgresql.yml
   roles:
     - manala.postgresql
   post_tasks:

--- a/manala.postgresql/tests/0600_privileges.yml
+++ b/manala.postgresql/tests/0600_privileges.yml
@@ -19,7 +19,7 @@
         privileges:
           - ALL
   pre_tasks:
-    - include: pre_tasks/postgresql.yml
+    - import_tasks: pre_tasks/postgresql.yml
   roles:
     - manala.postgresql
   post_tasks:

--- a/manala.proftpd/CHANGELOG.md
+++ b/manala.proftpd/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.proftpd/meta/main.yml
+++ b/manala.proftpd/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle proftpd
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.proftpd/tasks/main.yml
+++ b/manala.proftpd/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_proftpd
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_proftpd
 
 # Users
-- include: users.yml
+- import_tasks: users.yml
   tags:
     - manala_proftpd
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_proftpd
     - manala_proftpd.services

--- a/manala.proxmox/CHANGELOG.md
+++ b/manala.proxmox/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.proxmox/meta/main.yml
+++ b/manala.proxmox/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Proxmox configuration
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.proxmox/tasks/main.yml
+++ b/manala.proxmox/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_proxmox
 
 # Templates
-- include: templates.yml
+- import_tasks: templates.yml
   tags:
     - manala_proxmox
 
 # Storages
-- include: storages.yml
+- import_tasks: storages.yml
   tags:
     - manala_proxmox
 
 # Instances
-- include: instances.yml
+- import_tasks: instances.yml
   tags:
     - manala_proxmox

--- a/manala.redis/CHANGELOG.md
+++ b/manala.redis/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.redis/meta/main.yml
+++ b/manala.redis/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle redis
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.redis/tasks/main.yml
+++ b/manala.redis/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_redis
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_redis
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_redis
     - manala_redis.services

--- a/manala.redis/tests/0100_install.yml
+++ b/manala.redis/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.redis
   post_tasks:

--- a/manala.redis/tests/0101_install_sentinel.yml
+++ b/manala.redis/tests/0101_install_sentinel.yml
@@ -6,7 +6,7 @@
   vars:
     manala_redis_sentinel: true
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.redis
   post_tasks:

--- a/manala.redis/tests/0200_config.yml
+++ b/manala.redis/tests/0200_config.yml
@@ -7,7 +7,7 @@
     manala_redis_config:
       - port: 1234
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.redis
   post_tasks:

--- a/manala.redis/tests/0201_config_sentinel.yml
+++ b/manala.redis/tests/0201_config_sentinel.yml
@@ -9,7 +9,7 @@
       sentinel monitor: mymaster 127.0.0.1 6379 2
       sentinel down-after-milliseconds: mymaster 5000
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.redis
   post_tasks:

--- a/manala.redis/tests/0300_services.yml
+++ b/manala.redis/tests/0300_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.redis
   post_tasks:

--- a/manala.redis/tests/0301_services_sentinel.yml
+++ b/manala.redis/tests/0301_services_sentinel.yml
@@ -6,7 +6,7 @@
   vars:
     manala_redis_sentinel: true
   pre_tasks:
-    - include: pre_tasks/dotdeb.yml
+    - import_tasks: pre_tasks/dotdeb.yml
   roles:
     - manala.redis
   post_tasks:

--- a/manala.rsyslog/CHANGELOG.md
+++ b/manala.rsyslog/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.rsyslog/meta/main.yml
+++ b/manala.rsyslog/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Install and configure rsyslog
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.rsyslog/tasks/main.yml
+++ b/manala.rsyslog/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_rsyslog
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_rsyslog
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_rsyslog
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_rsyslog
     - manala_rsyslog.services

--- a/manala.rtail/CHANGELOG.md
+++ b/manala.rtail/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.rtail/meta/main.yml
+++ b/manala.rtail/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle rtail
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.rtail/tasks/main.yml
+++ b/manala.rtail/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_rtail
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_rtail
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_rtail
     - manala_rtail.services

--- a/manala.rtail/tests/0100_install.yml
+++ b/manala.rtail/tests/0100_install.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
       when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/rtail
         content: |

--- a/manala.rtail/tests/0200_config.yml
+++ b/manala.rtail/tests/0200_config.yml
@@ -7,9 +7,9 @@
     manala_rtail_config:
       - web-host: 127.0.0.1
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
       when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/rtail
         content: |

--- a/manala.rtail/tests/0300_services.yml
+++ b/manala.rtail/tests/0300_services.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
+    - import_tasks: pre_tasks/backports.yml
       when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/rtail
         content: |

--- a/manala.sensu/CHANGELOG.md
+++ b/manala.sensu/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.sensu/meta/main.yml
+++ b/manala.sensu/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Install and configure sensu
   license:             MIT
-  min_ansible_version: 2.1.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.sensu/tasks/main.yml
+++ b/manala.sensu/tasks/main.yml
@@ -1,32 +1,32 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_sensu
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_sensu
 
 # Gems
-- include: gems.yml
+- import_tasks: gems.yml
   tags:
     - manala_sensu
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_sensu
 
 # Checks
-- include: checks.yml
+- import_tasks: checks.yml
   tags:
     - manala_sensu
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_sensu
     - manala_sensu.services

--- a/manala.sensu/tests/0100_install.yml
+++ b/manala.sensu/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/sensu.yml
+    - import_tasks: pre_tasks/sensu.yml
   roles:
     - manala.sensu
   post_tasks:

--- a/manala.sensu/tests/0200_config.yml
+++ b/manala.sensu/tests/0200_config.yml
@@ -8,7 +8,7 @@
       EMBEDDED_RUBY: true
       LOG_LEVEL: warn
   pre_tasks:
-    - include: pre_tasks/sensu.yml
+    - import_tasks: pre_tasks/sensu.yml
   roles:
     - manala.sensu
   post_tasks:

--- a/manala.sensu/tests/0300_gems.yml
+++ b/manala.sensu/tests/0300_gems.yml
@@ -10,7 +10,7 @@
       - name: sensu-plugins-slack
         version: 1.0.0
   pre_tasks:
-    - include: pre_tasks/sensu.yml
+    - import_tasks: pre_tasks/sensu.yml
   roles:
     - manala.sensu
   post_tasks:

--- a/manala.sensu/tests/0400_configs.yml
+++ b/manala.sensu/tests/0400_configs.yml
@@ -20,7 +20,7 @@
           redis:
             host: localhost
   pre_tasks:
-    - include: pre_tasks/sensu.yml
+    - import_tasks: pre_tasks/sensu.yml
   roles:
     - manala.sensu
   post_tasks:

--- a/manala.sensu/tests/0600_services.yml
+++ b/manala.sensu/tests/0600_services.yml
@@ -9,7 +9,7 @@
       - sensu-api
       - sensu-client
   pre_tasks:
-    - include: pre_tasks/sensu.yml
+    - import_tasks: pre_tasks/sensu.yml
   roles:
     - manala.sensu
   post_tasks:

--- a/manala.shorewall/CHANGELOG.md
+++ b/manala.shorewall/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.shorewall/meta/main.yml
+++ b/manala.shorewall/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle shorewall
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.shorewall/tasks/main.yml
+++ b/manala.shorewall/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_shorewall
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_shorewall
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_shorewall

--- a/manala.sqlite/CHANGELOG.md
+++ b/manala.sqlite/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.sqlite/meta/main.yml
+++ b/manala.sqlite/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle SQLite
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.sqlite/tasks/main.yml
+++ b/manala.sqlite/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_sqlite

--- a/manala.ssh/CHANGELOG.md
+++ b/manala.ssh/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.ssh/meta/main.yml
+++ b/manala.ssh/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle ssh
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.ssh/tasks/main.yml
+++ b/manala.ssh/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_ssh
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_ssh
 
 # Known Hosts
-- include: known_hosts.yml
+- import_tasks: known_hosts.yml
   tags:
     - manala_ssh
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_ssh
     - manala_ssh.services

--- a/manala.sudo/CHANGELOG.md
+++ b/manala.sudo/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.sudo/meta/main.yml
+++ b/manala.sudo/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle sudo
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.sudo/tasks/main.yml
+++ b/manala.sudo/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_sudo
 
 # Sudoers
-- include: sudoers.yml
+- import_tasks: sudoers.yml
   tags:
     - manala_sudo

--- a/manala.supervisor/CHANGELOG.md
+++ b/manala.supervisor/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2018-03-28
 ### Added
 - Allow to pass 'environment' dictionary to supervisor configs

--- a/manala.supervisor/meta/main.yml
+++ b/manala.supervisor/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle supervisor
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.supervisor/tasks/main.yml
+++ b/manala.supervisor/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_supervisor
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_supervisor
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_supervisor
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_supervisor
     - manala_supervisor.services

--- a/manala.supervisor/tests/0100_install.yml
+++ b/manala.supervisor/tests/0100_install.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.supervisor
   post_tasks:

--- a/manala.supervisor/tests/0200_config.yml
+++ b/manala.supervisor/tests/0200_config.yml
@@ -8,9 +8,9 @@
       - unix_http_server:
         - file: /tmp/supervisor.sock
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.supervisor
   post_tasks:

--- a/manala.supervisor/tests/0300_configs.yml
+++ b/manala.supervisor/tests/0300_configs.yml
@@ -21,9 +21,9 @@
             - environment: BAR="12",FOO="bar"
 
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.supervisor
   post_tasks:

--- a/manala.supervisor/tests/0400_services.yml
+++ b/manala.supervisor/tests/0400_services.yml
@@ -4,9 +4,9 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/backports.yml
-      when:    ansible_distribution_release == 'wheezy'
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/backports.yml
+      when: ansible_distribution_release == 'wheezy'
+    - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.supervisor
   post_tasks:

--- a/manala.systemd/CHANGELOG.md
+++ b/manala.systemd/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Replace deprecated uses of "include"
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.systemd/meta/main.yml
+++ b/manala.systemd/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Configure systemd services
   license:             MIT
-  min_ansible_version: 2.2.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.systemd/tasks/main.yml
+++ b/manala.systemd/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_systemd
     - manala_systemd.services
     - manala.services
 
 # Configs - Tmpfiles
-- include: tmpfiles_configs.yml
+- import_tasks: tmpfiles_configs.yml
   tags:
     - manala_systemd
 
 # Configs - System
-- include: system_configs.yml
+- import_tasks: system_configs.yml
   tags:
     - manala_systemd

--- a/manala.telegraf/CHANGELOG.md
+++ b/manala.telegraf/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.telegraf/meta/main.yml
+++ b/manala.telegraf/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Elao
   description:         Setup and configure influxdata/telegraf
   license: MIT
-  min_ansible_version: 2.1.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.telegraf/tasks/main.yml
+++ b/manala.telegraf/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_telegraf
 
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_telegraf
 
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_telegraf
 
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_telegraf
     - manala_telegraf.services

--- a/manala.telegraf/tests/0100_install.yml
+++ b/manala.telegraf/tests/0100_install.yml
@@ -9,8 +9,8 @@
       - file: minimal_config.conf
         template: "{{ playbook_dir }}/fixtures/minimal_config.j2"
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.telegraf
   post_tasks:

--- a/manala.telegraf/tests/0200_config.yml
+++ b/manala.telegraf/tests/0200_config.yml
@@ -13,8 +13,8 @@
         - hostname: test.manala.dev
         - quiet: true
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.telegraf
   post_tasks:

--- a/manala.telegraf/tests/0300_configs.yml
+++ b/manala.telegraf/tests/0300_configs.yml
@@ -22,8 +22,8 @@
       - file: custom.conf
         template: "{{ playbook_dir }}/fixtures/custom.j2"
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.telegraf
   post_tasks:

--- a/manala.telegraf/tests/0400_services.yml
+++ b/manala.telegraf/tests/0400_services.yml
@@ -9,8 +9,8 @@
       - file: minimal_config.conf
         template: "{{ playbook_dir }}/fixtures/minimal_config.j2"
   pre_tasks:
-    - include: pre_tasks/disable_systemd.yml
-    - include: pre_tasks/influxdata.yml
+    - import_tasks: pre_tasks/disable_systemd.yml
+    - import_tasks: pre_tasks/influxdata.yml
   roles:
     - manala.telegraf
   post_tasks:

--- a/manala.timezone/CHANGELOG.md
+++ b/manala.timezone/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Replace deprecated uses of "include"
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.timezone/meta/main.yml
+++ b/manala.timezone/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle timezone
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.timezone/tasks/main.yml
+++ b/manala.timezone/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Default
-- include: default.yml
+- import_tasks: default.yml
   tags:
     - manala_timezone

--- a/manala.varnish/CHANGELOG.md
+++ b/manala.varnish/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.varnish/meta/main.yml
+++ b/manala.varnish/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   company:              Elao
   issue_tracker_url:    https://github.com/manala/ansible-role-varnish/issues
   license:              MIT
-  min_ansible_version:  1.9.4
+  min_ansible_version:  2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.varnish/tasks/main.yml
+++ b/manala.varnish/tasks/main.yml
@@ -1,22 +1,22 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_varnish
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_varnish
 
 # Configs
-- include: configs.yml
+- import_tasks: configs.yml
   tags:
     - manala_varnish
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_varnish
     - manala_varnish.services

--- a/manala.varnish/tests/0100_install.yml
+++ b/manala.varnish/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/varnish_4_0.yml
+    - import_tasks: pre_tasks/varnish_4_0.yml
     - copy:
         dest: /etc/apt/preferences.d/varnish
         content: |

--- a/manala.varnish/tests/0200_config.yml
+++ b/manala.varnish/tests/0200_config.yml
@@ -8,7 +8,7 @@
       - NFILES:  1310723
       - MEMLOCK: 82001
   pre_tasks:
-    - include: pre_tasks/varnish_4_0.yml
+    - import_tasks: pre_tasks/varnish_4_0.yml
     - copy:
         dest: /etc/apt/preferences.d/varnish
         content: |

--- a/manala.varnish/tests/0300_configs.yml
+++ b/manala.varnish/tests/0300_configs.yml
@@ -8,7 +8,7 @@
       - file: foo.vcl
         template: fixtures/foo.vcl.j2
   pre_tasks:
-    - include: pre_tasks/varnish_4_0.yml
+    - import_tasks: pre_tasks/varnish_4_0.yml
     - copy:
         dest: /etc/apt/preferences.d/varnish
         content: |

--- a/manala.varnish/tests/0400_services.yml
+++ b/manala.varnish/tests/0400_services.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/varnish_4_0.yml
+    - import_tasks: pre_tasks/varnish_4_0.yml
     - copy:
         dest: /etc/apt/preferences.d/varnish
         content: |

--- a/manala.vault/CHANGELOG.md
+++ b/manala.vault/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.vault/meta/main.yml
+++ b/manala.vault/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Install and configure hashicorp vault server
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.vault/tasks/main.yml
+++ b/manala.vault/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_vault
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_vault
 
 # Services
-- include: services.yml
+- import_tasks: services.yml
   tags:
     - manala_vault
     - manala_vault.services

--- a/manala.vault/tests/0100_install.yml
+++ b/manala.vault/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/vault
         content: |

--- a/manala.vault/tests/0200_config.yml
+++ b/manala.vault/tests/0200_config.yml
@@ -6,7 +6,7 @@
   vars:
     manala_vault_config_template: fixtures/config.j2
   pre_tasks:
-    - include: pre_tasks/manala.yml
+    - import_tasks: pre_tasks/manala.yml
     - copy:
         dest: /etc/apt/preferences.d/vault
         content: |

--- a/manala.vim/CHANGELOG.md
+++ b/manala.vim/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.vim/meta/main.yml
+++ b/manala.vim/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle vim
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.vim/tasks/main.yml
+++ b/manala.vim/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_vim
 
 # Config
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - manala_vim

--- a/manala.yarn/CHANGELOG.md
+++ b/manala.yarn/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.2] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.yarn/meta/main.yml
+++ b/manala.yarn/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle Yarn
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.yarn/tasks/main.yml
+++ b/manala.yarn/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_yarn

--- a/manala.yarn/tests/0100_install.yml
+++ b/manala.yarn/tests/0100_install.yml
@@ -4,7 +4,7 @@
   hosts: debian
   become: true
   pre_tasks:
-    - include: pre_tasks/yarn.yml
+    - import_tasks: pre_tasks/yarn.yml
     - copy:
         dest: /etc/apt/preferences.d/yarn
         content: |

--- a/manala.zsh/CHANGELOG.md
+++ b/manala.zsh/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Handle dependency packages to install
 
+### Changed
+- Replace deprecated uses of "include"
+
 ## [1.0.1] - 2017-12-06
 ### Added
 - Debian stretch support

--- a/manala.zsh/meta/main.yml
+++ b/manala.zsh/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   company:             Manala
   description:         Handle zsh
   license:             MIT
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/manala.zsh/tasks/main.yml
+++ b/manala.zsh/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 # Install
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - manala_zsh


### PR DESCRIPTION
Implicit `include` is deprecated starting from ansible 2.4
- [x] Replace by `import_tasks` when relevant
- [x] Move `when` conditions inside imported tasks
- [x] Use blocks when `include_tasks` is not an option to keep tags
- [x] Switch to ansible 2.4 as minimum version

Note: `manala.deploy` role and `manala.php` configs tasks are not part of this pr, due to their specific treatment