### PR TITLE
[All] Pass apt/yum module packages list directly to the `name` option

### DIFF
--- a/manala.alternatives/CHANGELOG.md
+++ b/manala.alternatives/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.alternatives/tests/0100_selections.yml
+++ b/manala.alternatives/tests/0100_selections.yml
@@ -9,11 +9,10 @@
         path:      /bin/ed
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - nano
+          - ed
         install_recommends: false
-      with_items:
-        - nano
-        - ed
     - alternatives:
         name: editor
         path: /bin/nano

--- a/manala.ansible/CHANGELOG.md
+++ b/manala.ansible/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Update base config template for ansible 2.5.0
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.3] - 2018-03-14
 ### Changed

--- a/manala.ansible/tasks/install.yml
+++ b/manala.ansible/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_ansible_install_packages|default(manala_ansible_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_ansible_install_packages|default(manala_ansible_install_packages_default, True) }}"

--- a/manala.apparmor/CHANGELOG.md
+++ b/manala.apparmor/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.apparmor/tasks/install.yml
+++ b/manala.apparmor/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_apparmor_install_packages|default(manala_apparmor_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_apparmor_install_packages|default(manala_apparmor_install_packages_default, True) }}"

--- a/manala.apt/CHANGELOG.md
+++ b/manala.apt/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update aptly key
 - Replace deprecated jinja tests used as filters
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.17] - 2018-03-21
 ### Added

--- a/manala.apt/tasks/install.yml
+++ b/manala.apt/tasks/install.yml
@@ -2,10 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    force: true
-    state: present
+    name: "{{ manala_apt_install_packages|default(manala_apt_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   "{{ manala_apt_cache_valid_time }}"
-  with_items: "{{ manala_apt_install_packages|default(manala_apt_install_packages_default, True) }}"

--- a/manala.apt/tasks/packages.yml
+++ b/manala.apt/tasks/packages.yml
@@ -2,8 +2,7 @@
 
 - name: packages > Deb present
   apt:
-    deb:   "{{ item }}"
-    state: present
+    deb: "{{ item }}"
   with_items: "{{ lookup(
       'manala_apt_packages',
       manala_apt_packages,
@@ -16,32 +15,29 @@
 
 - name: packages > Packages present
   apt:
-    package: "{{ item }}"
-    state:   present
+    name: "{{ lookup(
+        'manala_apt_packages',
+        manala_apt_packages,
+        wantstate='present',
+        wantmap=True,
+        wantdeb=False,
+        wantlist=True
+      )
+    }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   "{{ manala_apt_cache_valid_time }}"
-  with_items: "{{ lookup(
-      'manala_apt_packages',
-      manala_apt_packages,
-      wantstate='present',
-      wantmap=True,
-      wantdeb=False,
-      wantlist=True
-    )
-  }}"
 
 - name: packages > Packages absent
   apt:
-    package: "{{ item }}"
-    state:   absent
+    name: "{{ lookup(
+        'manala_apt_packages',
+        manala_apt_packages,
+        wantstate='absent',
+        wantmap=True,
+        wantlist=True
+      )
+    }}"
+    state: absent
     purge:      true
     autoremove: true
-  with_items: "{{ lookup(
-      'manala_apt_packages',
-      manala_apt_packages,
-      wantstate='absent',
-      wantmap=True,
-      wantlist=True
-    )
-  }}"

--- a/manala.apt/tests/0100_install.yml
+++ b/manala.apt/tests/0100_install.yml
@@ -5,12 +5,11 @@
   become: true
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - apt-transport-https
+          - openssl
+          - ca-certificates
         state: absent
-      with_items:
-        - apt-transport-https
-        - openssl
-        - ca-certificates
   roles:
     - manala.apt
   post_tasks:

--- a/manala.apt/tests/0700_packages.goss.yml
+++ b/manala.apt/tests/0700_packages.goss.yml
@@ -11,3 +11,7 @@ package:
     installed: true
     versions:
       - 1.2.4-3
+  wait-for-it:
+    installed: true
+  pscan:
+    installed: false

--- a/manala.apt/tests/0700_packages.yml
+++ b/manala.apt/tests/0700_packages.yml
@@ -13,18 +13,24 @@
       - package: pwgen
         state: absent
       - http://snapshot.debian.org/archive/debian/20111228T033508Z/pool/main/s/spinner/spinner_1.2.4-3_amd64.deb
+      - package: http://snapshot.debian.org/archive/debian/20171229T170214Z/pool/main/w/wait-for-it/wait-for-it_0.0~git20170723-1_all.deb
+        state: absent
+      - package: http://snapshot.debian.org/archive/debian/20160619T164515Z/pool/main/w/wait-for-it/wait-for-it_0.0~git20160501-1_all.deb
+        state: present
+      - package: pscan
+        state: absent
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - e3
+          - telnet
         state: absent
-      with_items:
-        - e3
-        - telnet
     - apt:
-        name:  "{{ item }}"
+        name:
+          - pwgen
         install_recommends: false
-      with_items:
-        - pwgen
+    - apt:
+        deb: http://snapshot.debian.org/archive/debian-archive/20120328T092752Z/debian/pool/main/p/pscan/pscan_1.2-9_amd64.deb
   roles:
     - manala.apt
   post_tasks:

--- a/manala.aptly/CHANGELOG.md
+++ b/manala.aptly/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.aptly/tasks/install.yml
+++ b/manala.aptly/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_aptly_install_packages|default(manala_aptly_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_aptly_install_packages|default(manala_aptly_install_packages_default, True) }}"

--- a/manala.backup-manager/CHANGELOG.md
+++ b/manala.backup-manager/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replace deprecated uses of "include"
 - Use native config template default values type when possible
 - Allow S3 configuration for MySQL and PGSQL
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.backup-manager/tasks/install.yml
+++ b/manala.backup-manager/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_backup_manager_install_packages|default(manala_backup_manager_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_backup_manager_install_packages|default(manala_backup_manager_install_packages_default, True) }}"

--- a/manala.beanstalkd/CHANGELOG.md
+++ b/manala.beanstalkd/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.beanstalkd/tasks/install.yml
+++ b/manala.beanstalkd/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_beanstalkd_install_packages|default(manala_beanstalkd_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_beanstalkd_install_packages|default(manala_beanstalkd_install_packages_default, True) }}"

--- a/manala.bind/CHANGELOG.md
+++ b/manala.bind/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Replace deprecated jinja tests used as filters
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2018-03-16
 ### Added

--- a/manala.bind/tasks/install.yml
+++ b/manala.bind/tasks/install.yml
@@ -2,12 +2,10 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{
+      manala_bind_install_packages|default(manala_bind_install_packages_default, True)
+      + ['python-dnspython']
+    }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{
-    manala_bind_install_packages|default(manala_bind_install_packages_default, True)
-    + ['python-dnspython']
-  }}"

--- a/manala.bind/tests/0700_zones_records.yml
+++ b/manala.bind/tests/0700_zones_records.yml
@@ -31,9 +31,8 @@
     - manala.bind
   post_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - bind9-host
         install_recommends: false
-      with_items:
-        - bind9-host
     - name: Goss
       command: goss --gossfile {{ test }}.goss.yml validate

--- a/manala.cloud-init/CHANGELOG.md
+++ b/manala.cloud-init/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.cloud-init/tasks/install.yml
+++ b/manala.cloud-init/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_cloud_init_install_packages|default(manala_cloud_init_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_cloud_init_install_packages|default(manala_cloud_init_install_packages_default, True) }}"

--- a/manala.composer/CHANGELOG.md
+++ b/manala.composer/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.composer/tasks/install.yml
+++ b/manala.composer/tasks/install.yml
@@ -2,13 +2,10 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    force: true
-    state: present
+    name: "{{ manala_composer_install_packages|default(manala_composer_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_composer_install_packages|default(manala_composer_install_packages_default, True) }}"
 
 - name: install > Stat bin
   stat:

--- a/manala.composer/tests/0100_install.yml
+++ b/manala.composer/tests/0100_install.yml
@@ -5,10 +5,9 @@
   become: true
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'stretch')|ternary('php7.0-cli','php5-cli') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'stretch')|ternary('php7.0-cli','php5-cli') }}"
   roles:
     - manala.composer
   post_tasks:

--- a/manala.composer/tests/0200_users_auth.yml
+++ b/manala.composer/tests/0200_users_auth.yml
@@ -15,10 +15,9 @@
               - password: my-secret-password1
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'stretch')|ternary('php7.0-cli','php5-cli') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'stretch')|ternary('php7.0-cli','php5-cli') }}"
   roles:
     - manala.composer
   post_tasks:

--- a/manala.cron/CHANGELOG.md
+++ b/manala.cron/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.cron/tasks/install.yml
+++ b/manala.cron/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_cron_install_packages|default(manala_cron_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_cron_install_packages|default(manala_cron_install_packages_default, True) }}"

--- a/manala.deploy/CHANGELOG.md
+++ b/manala.deploy/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.5] - 2017-12-20
 ### Fixed

--- a/manala.deploy/tests/pre_tasks/rsync.yml
+++ b/manala.deploy/tests/pre_tasks/rsync.yml
@@ -1,7 +1,6 @@
 ---
 
 - apt:
-    package: "{{ item }}"
+    name:
+      - rsync
     install_recommends: false
-  with_items:
-    - rsync

--- a/manala.deploy/tests/pre_tasks/ssh.yml
+++ b/manala.deploy/tests/pre_tasks/ssh.yml
@@ -1,7 +1,6 @@
 ---
 
 - apt:
-    package: "{{ item }}"
+    name:
+      - ssh
     install_recommends: false
-  with_items:
-    - ssh

--- a/manala.dhcp/CHANGELOG.md
+++ b/manala.dhcp/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.0] - 2018-03-15
 ### Added

--- a/manala.dhcp/tasks/install.yml
+++ b/manala.dhcp/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_dhcp_install_packages|default(manala_dhcp_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_dhcp_install_packages|default(manala_dhcp_install_packages_default, True) }}"

--- a/manala.dnsmasq/CHANGELOG.md
+++ b/manala.dnsmasq/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.dnsmasq/tasks/install.yml
+++ b/manala.dnsmasq/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_dnsmasq_install_packages|default(manala_dnsmasq_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_dnsmasq_install_packages|default(manala_dnsmasq_install_packages_default, True) }}"

--- a/manala.docker/CHANGELOG.md
+++ b/manala.docker/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.10] - 2018-02-22
 ### Added

--- a/manala.docker/tasks/install.yml
+++ b/manala.docker/tasks/install.yml
@@ -2,15 +2,13 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{
+      manala_docker_install_packages|default(manala_docker_install_packages_default, True)
+      + (manala_docker_containers|length > 0)|ternary(
+        ['python-docker'],
+        []
+      )
+    }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{
-    manala_docker_install_packages|default(manala_docker_install_packages_default, True)
-    + (manala_docker_containers|length > 0)|ternary(
-      ['python-docker'],
-      []
-    )
-  }}"

--- a/manala.elasticsearch/CHANGELOG.md
+++ b/manala.elasticsearch/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replace deprecated jinja tests used as filters
 - Add curl to pretty in Goss tests to check installed version
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.elasticsearch/tasks/install.yml
+++ b/manala.elasticsearch/tasks/install.yml
@@ -2,12 +2,10 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_elasticsearch_install_packages|default(manala_elasticsearch_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_elasticsearch_install_packages|default(manala_elasticsearch_install_packages_default, True) }}"
 
 - name: install > Version
   shell: "dpkg -s elasticsearch | grep \"Version: \" | sed -e 's/Version: //g'"

--- a/manala.elasticsearch/tests/0200_install.1.5.yml
+++ b/manala.elasticsearch/tests/0200_install.1.5.yml
@@ -15,10 +15,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0201_install.1.6.yml
+++ b/manala.elasticsearch/tests/0201_install.1.6.yml
@@ -15,10 +15,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0202_install.1.7.yml
+++ b/manala.elasticsearch/tests/0202_install.1.7.yml
@@ -15,10 +15,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0203_install.2.yml
+++ b/manala.elasticsearch/tests/0203_install.2.yml
@@ -15,10 +15,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0204_install.5.yml
+++ b/manala.elasticsearch/tests/0204_install.5.yml
@@ -15,10 +15,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - openjdk-8-jre-headless
         install_recommends: false
-      with_items:
-        - openjdk-8-jre-headless
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0205_install.6.yml
+++ b/manala.elasticsearch/tests/0205_install.6.yml
@@ -15,10 +15,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - openjdk-8-jre-headless
         install_recommends: false
-      with_items:
-        - openjdk-8-jre-headless
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0300_config.1.5.yml
+++ b/manala.elasticsearch/tests/0300_config.1.5.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0301_config.1.6.yml
+++ b/manala.elasticsearch/tests/0301_config.1.6.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0302_config.1.7.yml
+++ b/manala.elasticsearch/tests/0302_config.1.7.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0303_config.2.yml
+++ b/manala.elasticsearch/tests/0303_config.2.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0304_config.5.yml
+++ b/manala.elasticsearch/tests/0304_config.5.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - openjdk-8-jre-headless
         install_recommends: false
-      with_items:
-        - openjdk-8-jre-headless
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0500_plugins.1.5.yml
+++ b/manala.elasticsearch/tests/0500_plugins.1.5.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0501_plugins.1.6.yml
+++ b/manala.elasticsearch/tests/0501_plugins.1.6.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0502_plugins.1.7.yml
+++ b/manala.elasticsearch/tests/0502_plugins.1.7.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.elasticsearch/tests/0503_plugins.2.yml
+++ b/manala.elasticsearch/tests/0503_plugins.2.yml
@@ -18,10 +18,9 @@
           Pin-Priority: 900
       when: ansible_distribution_release == 'jessie'
     - apt:
-        name:  "{{ item }}"
+        name:
+          - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
         install_recommends: false
-      with_items:
-        - "{{ 'openjdk-7-jre-headless' if (ansible_distribution_release == 'wheezy') else 'openjdk-8-jre-headless' }}"
   roles:
     - manala.elasticsearch
   post_tasks:

--- a/manala.fail2ban/CHANGELOG.md
+++ b/manala.fail2ban/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.fail2ban/tasks/install.yml
+++ b/manala.fail2ban/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_fail2ban_install_packages|default(manala_fail2ban_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_fail2ban_install_packages|default(manala_fail2ban_install_packages_default, True) }}"

--- a/manala.git/CHANGELOG.md
+++ b/manala.git/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.git/tasks/install.yml
+++ b/manala.git/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_git_install_packages|default(manala_git_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_git_install_packages|default(manala_git_install_packages_default, True) }}"

--- a/manala.gitlab/CHANGELOG.md
+++ b/manala.gitlab/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.gitlab/tasks/install.yml
+++ b/manala.gitlab/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_gitlab_install_packages|default(manala_gitlab_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_gitlab_install_packages|default(manala_gitlab_install_packages_default, True) }}"

--- a/manala.grafana/CHANGELOG.md
+++ b/manala.grafana/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix missings ansible 2.1 deprecation "Supplying headers via HEADER_* is deprecated"
 - Replace deprecated jinja tests used as filters
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.grafana/tasks/install.yml
+++ b/manala.grafana/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_grafana_install_packages|default(manala_grafana_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_grafana_install_packages|default(manala_grafana_install_packages_default, True) }}"

--- a/manala.haproxy/CHANGELOG.md
+++ b/manala.haproxy/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2018-03-28
 ### Changed

--- a/manala.haproxy/tasks/install.yml
+++ b/manala.haproxy/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_haproxy_install_packages|default(manala_haproxy_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_haproxy_install_packages|default(manala_haproxy_install_packages_default, True) }}"

--- a/manala.heka/CHANGELOG.md
+++ b/manala.heka/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.heka/tasks/install.yml
+++ b/manala.heka/tasks/install.yml
@@ -2,12 +2,10 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_heka_install_packages|default(manala_heka_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_heka_install_packages|default(manala_heka_install_packages_default, True) }}"
 
 - name: install > Lua encoders
   template:

--- a/manala.hugo/CHANGELOG.md
+++ b/manala.hugo/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.hugo/tasks/install.yml
+++ b/manala.hugo/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_hugo_install_packages|default(manala_hugo_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_hugo_install_packages|default(manala_hugo_install_packages_default, True) }}"

--- a/manala.influxdb/CHANGELOG.md
+++ b/manala.influxdb/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2018-03-12
 ### Changed

--- a/manala.influxdb/tasks/install.yml
+++ b/manala.influxdb/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_influxdb_install_packages|default(manala_influxdb_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_influxdb_install_packages|default(manala_influxdb_install_packages_default, True) }}"

--- a/manala.java/CHANGELOG.md
+++ b/manala.java/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Replace deprecated jinja tests used as filters
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.java/tasks/install.yml
+++ b/manala.java/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_java_install_packages|default(manala_java_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_java_install_packages|default(manala_java_install_packages_default, True) }}"

--- a/manala.keepalived/CHANGELOG.md
+++ b/manala.keepalived/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.keepalived/tasks/install.yml
+++ b/manala.keepalived/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_keepalived_install_packages|default(manala_keepalived_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_keepalived_install_packages|default(manala_keepalived_install_packages_default, True) }}"

--- a/manala.locales/CHANGELOG.md
+++ b/manala.locales/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt/yum module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.locales/tasks/debian/install.yml
+++ b/manala.locales/tasks/debian/install.yml
@@ -2,12 +2,10 @@
 
 - name: Debian > install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name:
+      - locales # Provides "locale-gen" binary for module "locale_gen".
+                # Note that "locales" package has a dependency on
+                # "libc-bin" package, providing "locale" binary
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items:
-    - locales # Provides "locale-gen" binary for module "locale_gen".
-              # Note that "locales" package has a dependency on
-              # "libc-bin" package, providing "locale" binary

--- a/manala.locales/tasks/redhat/install.yml
+++ b/manala.locales/tasks/redhat/install.yml
@@ -2,8 +2,6 @@
 
 - name: RedHat > install > Packages
   yum:
-    name:  "{{ item }}"
-    state: present
+    name:
+      - glibc-common # Provides "localedef" and "locale" binary
     update_cache: true
-  with_items:
-    - glibc-common # Provides "localedef" and "locale" binary

--- a/manala.locales/tests/0300_codes_default.yml
+++ b/manala.locales/tests/0300_codes_default.yml
@@ -12,7 +12,8 @@
     # which provides "/etc/profile.d/lang.sh",
     # to handle properly locale settings
     - yum:
-        name: initscripts
+        name:
+          - initscripts
       when: ansible_os_family|lower == 'redhat'
   roles:
     - manala.locales

--- a/manala.logentries/CHANGELOG.md
+++ b/manala.logentries/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.0] - 2017-06-09
 ### Added

--- a/manala.logentries/tasks/install.yml
+++ b/manala.logentries/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_logentries_install_packages|default(manala_logentries_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_logentries_install_packages|default(manala_logentries_install_packages_default, True) }}"

--- a/manala.logrotate/CHANGELOG.md
+++ b/manala.logrotate/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.logrotate/tasks/install.yml
+++ b/manala.logrotate/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_logrotate_install_packages|default(manala_logrotate_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_logrotate_install_packages|default(manala_logrotate_install_packages_default, True) }}"

--- a/manala.mailhog/CHANGELOG.md
+++ b/manala.mailhog/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.mailhog/tasks/install.yml
+++ b/manala.mailhog/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_mailhog_install_packages|default(manala_mailhog_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_mailhog_install_packages|default(manala_mailhog_install_packages_default, True) }}"

--- a/manala.make/CHANGELOG.md
+++ b/manala.make/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.make/tasks/install.yml
+++ b/manala.make/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_make_install_packages|default(manala_make_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_make_install_packages|default(manala_make_install_packages_default, True) }}"

--- a/manala.maxscale/CHANGELOG.md
+++ b/manala.maxscale/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.maxscale/tasks/install.yml
+++ b/manala.maxscale/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_maxscale_install_packages|default(manala_maxscale_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_maxscale_install_packages|default(manala_maxscale_install_packages_default, True) }}"

--- a/manala.mongo-express/CHANGELOG.md
+++ b/manala.mongo-express/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.mongo-express/tasks/install.yml
+++ b/manala.mongo-express/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_mongo_express_install_packages|default(manala_mongo_express_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_mongo_express_install_packages|default(manala_mongo_express_install_packages_default, True) }}"

--- a/manala.mongodb/CHANGELOG.md
+++ b/manala.mongodb/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.mongodb/tasks/install.yml
+++ b/manala.mongodb/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_mongodb_install_packages|default(manala_mongodb_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_mongodb_install_packages|default(manala_mongodb_install_packages_default, True) }}"

--- a/manala.mount/CHANGELOG.md
+++ b/manala.mount/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.mount/tests/0100_points.yml
+++ b/manala.mount/tests/0100_points.yml
@@ -11,10 +11,9 @@
         opts: bind
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - bindfs
         install_recommends: false
-      with_items:
-        - bindfs
   roles:
     - manala.mount
   post_tasks:

--- a/manala.mysql/CHANGELOG.md
+++ b/manala.mysql/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.3] - 2018-03-28
 ### Changed

--- a/manala.mysql/tasks/install.yml
+++ b/manala.mysql/tasks/install.yml
@@ -2,19 +2,17 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{
+      manala_mysql_install_packages|default(manala_mysql_install_packages_default, True)
+      + (
+        (manala_mysql_users|length > 0)
+        or (manala_mysql_databases|length > 0)
+        or (manala_mysql_replications|length > 0)
+      )|ternary(
+        ['python-mysqldb'],
+        []
+      )
+    }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{
-    manala_mysql_install_packages|default(manala_mysql_install_packages_default, True)
-    + (
-      (manala_mysql_users|length > 0)
-      or (manala_mysql_databases|length > 0)
-      or (manala_mysql_replications|length > 0)
-    )|ternary(
-      ['python-mysqldb'],
-      []
-    )
-  }}"

--- a/manala.nginx/CHANGELOG.md
+++ b/manala.nginx/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2018-03-01
 ### Changed

--- a/manala.nginx/tasks/install.yml
+++ b/manala.nginx/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_nginx_install_packages|default(manala_nginx_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_nginx_install_packages|default(manala_nginx_install_packages_default, True) }}"

--- a/manala.ngrok/CHANGELOG.md
+++ b/manala.ngrok/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.ngrok/tasks/install.yml
+++ b/manala.ngrok/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_ngrok_install_packages|default(manala_ngrok_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_ngrok_install_packages|default(manala_ngrok_install_packages_default, True) }}"

--- a/manala.nodejs/CHANGELOG.md
+++ b/manala.nodejs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.3] - 2017-12-06
 ### Added

--- a/manala.nodejs/tasks/install.yml
+++ b/manala.nodejs/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_nodejs_install_packages|default(manala_nodejs_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_nodejs_install_packages|default(manala_nodejs_install_packages_default, True) }}"

--- a/manala.npm/CHANGELOG.md
+++ b/manala.npm/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.npm/tests/0100_packages.yml
+++ b/manala.npm/tests/0100_packages.yml
@@ -20,10 +20,9 @@
           Pin:          origin deb.nodesource.com
           Pin-Priority: 900
     - apt:
-        name:  "{{ item }}"
+        name:
+          - nodejs
         install_recommends: false
-      with_items:
-        - nodejs
   roles:
     - manala.npm
   post_tasks:

--- a/manala.ntp/CHANGELOG.md
+++ b/manala.ntp/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.ntp/tasks/install.yml
+++ b/manala.ntp/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_ntp_install_packages|default(manala_ntp_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_ntp_install_packages|default(manala_ntp_install_packages_default, True) }}"

--- a/manala.oauth2-proxy/CHANGELOG.md
+++ b/manala.oauth2-proxy/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.oauth2-proxy/tasks/install.yml
+++ b/manala.oauth2-proxy/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_oauth2_proxy_install_packages|default(manala_oauth2_proxy_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_oauth2_proxy_install_packages|default(manala_oauth2_proxy_install_packages_default, True) }}"

--- a/manala.ohmyzsh/CHANGELOG.md
+++ b/manala.ohmyzsh/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.5] - 2018-01-31
 ### Added

--- a/manala.ohmyzsh/tests/0200_install.yml
+++ b/manala.ohmyzsh/tests/0200_install.yml
@@ -5,11 +5,10 @@
   become: true
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - git
+          - zsh
         install_recommends: false
-      with_items:
-        - git
-        - zsh
   roles:
     - manala.ohmyzsh
   post_tasks:

--- a/manala.ohmyzsh/tests/0300_themes.yml
+++ b/manala.ohmyzsh/tests/0300_themes.yml
@@ -5,11 +5,10 @@
   become: true
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - git
+          - zsh
         install_recommends: false
-      with_items:
-        - git
-        - zsh
   roles:
     - manala.ohmyzsh
   post_tasks:

--- a/manala.ohmyzsh/tests/0400_users.yml
+++ b/manala.ohmyzsh/tests/0400_users.yml
@@ -10,11 +10,10 @@
         template: users/php.dev.j2
   pre_tasks:
     - apt:
-        name:  "{{ item }}"
+        name:
+          - git
+          - zsh
         install_recommends: false
-      with_items:
-        - git
-        - zsh
   roles:
     - manala.ohmyzsh
   post_tasks:

--- a/manala.opcache-dashboard/CHANGELOG.md
+++ b/manala.opcache-dashboard/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-08
 ### Added

--- a/manala.opcache-dashboard/tasks/install.yml
+++ b/manala.opcache-dashboard/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_opcache_dashboard_install_packages|default(manala_opcache_dashboard_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_opcache_dashboard_install_packages|default(manala_opcache_dashboard_install_packages_default, True) }}"

--- a/manala.opcache-dashboard/tests/0100_install.php_5.6.yml
+++ b/manala.opcache-dashboard/tests/0100_install.php_5.6.yml
@@ -9,10 +9,9 @@
     - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
-        package: "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.opcache-dashboard

--- a/manala.opcache-dashboard/tests/0101_install.php_7.2.yml
+++ b/manala.opcache-dashboard/tests/0101_install.php_7.2.yml
@@ -6,10 +6,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.opcache-dashboard

--- a/manala.pam-ssh-agent-auth/CHANGELOG.md
+++ b/manala.pam-ssh-agent-auth/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.pam-ssh-agent-auth/tasks/install.yml
+++ b/manala.pam-ssh-agent-auth/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_pam_ssh_agent_auth_install_packages|default(manala_pam_ssh_agent_auth_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_pam_ssh_agent_auth_install_packages|default(manala_pam_ssh_agent_auth_install_packages_default, True) }}"

--- a/manala.phantomjs/CHANGELOG.md
+++ b/manala.phantomjs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.phantomjs/tasks/install.yml
+++ b/manala.phantomjs/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_phantomjs_install_packages|default(manala_phantomjs_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_phantomjs_install_packages|default(manala_phantomjs_install_packages_default, True) }}"

--- a/manala.php/CHANGELOG.md
+++ b/manala.php/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Replace deprecated jinja tests used as filters
+- Pass apt module packages list directly to the `name` option
 
 ### Fixed
 - Give opportunity to specify certificates validation on application download

--- a/manala.php/tasks/blackfire.yml
+++ b/manala.php/tasks/blackfire.yml
@@ -2,14 +2,12 @@
 
 - name: blackfire > Install packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name:
+      - blackfire-agent
+      - blackfire-php
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items:
-    - blackfire-agent
-    - blackfire-php
   notify:
     - php fpm restart
 

--- a/manala.php/tasks/install.yml
+++ b/manala.php/tasks/install.yml
@@ -2,72 +2,69 @@
 
 - name: install > Packages presents
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{
+      lookup(
+        'manala_php_packages',
+        (
+          lookup(
+            'manala_php_sapis',
+            manala_php_sapis|default(manala_php_sapis_default, True),
+            manala_php_versions[manala_php_version|string],
+            wantstate='present',
+            wantmap=true,
+            wantlist=true
+          )
+          + lookup(
+            'manala_php_extensions',
+            manala_php_extensions,
+            manala_php_versions[manala_php_version|string],
+            wantstate='present',
+            wantmap=true,
+            wantlist=true
+          )
+        ),
+        manala_php_version|string,
+        manala_php_extensions_pecl,
+        manala_php_extensions_pecl_versioned,
+        wantlist=true
+      )
+    }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{
-    lookup(
-      'manala_php_packages',
-      (
-        lookup(
-          'manala_php_sapis',
-          manala_php_sapis|default(manala_php_sapis_default, True),
-          manala_php_versions[manala_php_version|string],
-          wantstate='present',
-          wantmap=true,
-          wantlist=true
-        )
-        + lookup(
-          'manala_php_extensions',
-          manala_php_extensions,
-          manala_php_versions[manala_php_version|string],
-          wantstate='present',
-          wantmap=true,
-          wantlist=true
-        )
-      ),
-      manala_php_version|string,
-      manala_php_extensions_pecl,
-      manala_php_extensions_pecl_versioned,
-      wantlist=true
-    )
-  }}"
 
 - name: install > Packages absents
   apt:
-    name:  "{{ item }}"
+    name: "{{
+      lookup(
+        'manala_php_packages',
+        (
+          lookup(
+            'manala_php_sapis',
+            manala_php_sapis|default(manala_php_sapis_default, True),
+            manala_php_versions[manala_php_version|string],
+            wantstate='absent',
+            wantmap=true,
+            wantlist=true
+          )
+          + lookup(
+            'manala_php_extensions',
+            manala_php_extensions,
+            manala_php_versions[manala_php_version|string],
+            wantstate='absent',
+            wantmap=true,
+            wantlist=true
+          )
+        ),
+        manala_php_version|string,
+        manala_php_extensions_pecl,
+        manala_php_extensions_pecl_versioned,
+        wantlist=true
+      )
+    }}"
     state: absent
     purge:      true
     autoremove: true
-  with_items: "{{
-    lookup(
-      'manala_php_packages',
-      (
-        lookup(
-          'manala_php_sapis',
-          manala_php_sapis|default(manala_php_sapis_default, True),
-          manala_php_versions[manala_php_version|string],
-          wantstate='absent',
-          wantmap=true,
-          wantlist=true
-        )
-        + lookup(
-          'manala_php_extensions',
-          manala_php_extensions,
-          manala_php_versions[manala_php_version|string],
-          wantstate='absent',
-          wantmap=true,
-          wantlist=true
-        )
-      ),
-      manala_php_version|string,
-      manala_php_extensions_pecl,
-      manala_php_extensions_pecl_versioned,
-      wantlist=true
-    )
-  }}"
 
 # Use dpkg-query to find out installed packages
 - name: install > Exclusive - Packages presents
@@ -80,13 +77,11 @@
 # Ensure debfoster is presents if exclusive mode is set
 - name: install > Exclusive - Packages requirements
   apt:
-    name:  "{{ item }}"
-    state: present
+    name:
+      - debfoster
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items:
-    - debfoster
   when: manala_php_sapis_exclusive or manala_php_extensions_exclusive
 
 # Use debfoster to find out each package dependencies
@@ -129,50 +124,50 @@
 
 - name: install > Exclusive - Packages absents
   apt:
-    name:  "{{ item }}"
+    name: "{{
+      lookup(
+        'manala_php_install_packages_exclusive',
+        lookup(
+          'manala_php_packages',
+          (
+            lookup(
+              'manala_php_sapis',
+              manala_php_sapis|default(manala_php_sapis_default, True),
+              manala_php_versions[manala_php_version|string],
+              wantstate='present',
+              wantmap=true,
+              wantlist=true
+            )
+            + lookup(
+              'manala_php_extensions',
+              manala_php_extensions,
+              manala_php_versions[manala_php_version|string],
+              wantstate='present',
+              wantmap=true,
+              wantlist=true
+            )
+          ),
+          manala_php_version|string,
+          manala_php_extensions_pecl,
+          manala_php_extensions_pecl_versioned,
+          wantlist=true
+        ),
+        lookup(
+          'manala_php_packages',
+          manala_php_versions[manala_php_version|string]['sapis'],
+          manala_php_version|string,
+          manala_php_extensions_pecl,
+          manala_php_extensions_pecl_versioned,
+          wantlist=true
+        ),
+        __manala_php_install_packages_presents_result.stdout_lines|default([]),
+        __manala_php_install_packages_dependencies_result.stdout_lines|default([]),
+        manala_php_sapis_exclusive,
+        manala_php_extensions_exclusive,
+        wantlist=true
+      )
+    }}"
     state: absent
     purge:      true
     autoremove: true
-  with_manala_php_install_packages_exclusive:
-    - "{{
-      lookup(
-        'manala_php_packages',
-        (
-          lookup(
-            'manala_php_sapis',
-            manala_php_sapis|default(manala_php_sapis_default, True),
-            manala_php_versions[manala_php_version|string],
-            wantstate='present',
-            wantmap=true,
-            wantlist=true
-          )
-          + lookup(
-            'manala_php_extensions',
-            manala_php_extensions,
-            manala_php_versions[manala_php_version|string],
-            wantstate='present',
-            wantmap=true,
-            wantlist=true
-          )
-        ),
-        manala_php_version|string,
-        manala_php_extensions_pecl,
-        manala_php_extensions_pecl_versioned,
-        wantlist=true
-      )
-    }}"
-    - "{{
-      lookup(
-        'manala_php_packages',
-        manala_php_versions[manala_php_version|string]['sapis'],
-        manala_php_version|string,
-        manala_php_extensions_pecl,
-        manala_php_extensions_pecl_versioned,
-        wantlist=true
-      )
-    }}"
-    - "{{ __manala_php_install_packages_presents_result.stdout_lines|default([]) }}"
-    - "{{ __manala_php_install_packages_dependencies_result.stdout_lines|default([]) }}"
-    - "{{ manala_php_sapis_exclusive }}"
-    - "{{ manala_php_extensions_exclusive }}"
   when: manala_php_sapis_exclusive or manala_php_extensions_exclusive

--- a/manala.php/tests/0200_install.5.4.yml
+++ b/manala.php/tests/0200_install.5.4.yml
@@ -29,12 +29,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cgi  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cgi  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0201_install.5.5.yml
+++ b/manala.php/tests/0201_install.5.5.yml
@@ -29,12 +29,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cgi  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cgi  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0202_install.5.6_dotdeb.yml
+++ b/manala.php/tests/0202_install.5.6_dotdeb.yml
@@ -29,12 +29,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cgi  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cgi  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0203_install.5.6.yml
+++ b/manala.php/tests/0203_install.5.6.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5.6-cgi  # Sapi
+          - php5.6-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php5.6-cgi  # Sapi
-        - php5.6-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0204_install.7.0_dotdeb.yml
+++ b/manala.php/tests/0204_install.7.0_dotdeb.yml
@@ -29,12 +29,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cgi  # Sapi
+          - php7.0-tidy # Native extension
+          - php7.0-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.0-cgi  # Sapi
-        - php7.0-tidy # Native extension
-        - php7.0-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0205_install.7.0.yml
+++ b/manala.php/tests/0205_install.7.0.yml
@@ -29,12 +29,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cgi  # Sapi
+          - php7.0-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.0-cgi  # Sapi
-        - php7.0-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0206_install.7.1.yml
+++ b/manala.php/tests/0206_install.7.1.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.1-cgi  # Sapi
+          - php7.1-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.1-cgi  # Sapi
-        - php7.1-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0207_install.7.2.yml
+++ b/manala.php/tests/0207_install.7.2.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-cgi  # Sapi
+          - php7.2-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.2-cgi  # Sapi
-        - php7.2-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0210_install_exclusive.5.4.yml
+++ b/manala.php/tests/0210_install_exclusive.5.4.yml
@@ -23,12 +23,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cgi  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cgi  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0211_install_exclusive.5.5.yml
+++ b/manala.php/tests/0211_install_exclusive.5.5.yml
@@ -23,12 +23,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cgi  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cgi  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0212_install_exclusive.5.6_dotdeb.yml
+++ b/manala.php/tests/0212_install_exclusive.5.6_dotdeb.yml
@@ -23,12 +23,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cgi  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cgi  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0213_install_exclusive.5.6.yml
+++ b/manala.php/tests/0213_install_exclusive.5.6.yml
@@ -23,12 +23,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5.6-cgi  # Sapi
+          - php5.6-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php5.6-cgi  # Sapi
-        - php5.6-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0214_install_exclusive.7.0_dotdeb.yml
+++ b/manala.php/tests/0214_install_exclusive.7.0_dotdeb.yml
@@ -23,12 +23,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cgi  # Sapi
+          - php7.0-tidy # Native extension
+          - php7.0-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.0-cgi  # Sapi
-        - php7.0-tidy # Native extension
-        - php7.0-apcu # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0215_install_exclusive.7.0.yml
+++ b/manala.php/tests/0215_install_exclusive.7.0.yml
@@ -23,12 +23,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cgi  # Sapi
+          - php7.0-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.0-cgi  # Sapi
-        - php7.0-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0216_install_exclusive.7.1.yml
+++ b/manala.php/tests/0216_install_exclusive.7.1.yml
@@ -22,12 +22,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.1-cgi  # Sapi
+          - php7.1-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.1-cgi  # Sapi
-        - php7.1-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0217_install_exclusive.7.2.yml
+++ b/manala.php/tests/0217_install_exclusive.7.2.yml
@@ -22,12 +22,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-cgi  # Sapi
+          - php7.2-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.2-cgi  # Sapi
-        - php7.2-tidy # Native extension
-        - php-apcu    # Pecl extension
   roles:
     - manala.php
   post_tasks:

--- a/manala.php/tests/0300_extensions.5.4.yml
+++ b/manala.php/tests/0300_extensions.5.4.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cli  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cli  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
     - command: php5dismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0301_extensions.5.5.yml
+++ b/manala.php/tests/0301_extensions.5.5.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cli  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cli  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
     - command: php5dismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0302_extensions.5.6_dotdeb.yml
+++ b/manala.php/tests/0302_extensions.5.6_dotdeb.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cli  # Sapi
+          - php5-tidy # Native extension
+          - php5-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php5-cli  # Sapi
-        - php5-tidy # Native extension
-        - php5-apcu # Pecl extension
     - command: php5dismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0303_extensions.5.6.yml
+++ b/manala.php/tests/0303_extensions.5.6.yml
@@ -27,12 +27,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5.6-cli  # Sapi
+          - php5.6-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php5.6-cli  # Sapi
-        - php5.6-tidy # Native extension
-        - php-apcu    # Pecl extension
     - command: phpdismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0304_extensions.7.0_dotdeb.yml
+++ b/manala.php/tests/0304_extensions.7.0_dotdeb.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cli  # Sapi
+          - php7.0-tidy # Native extension
+          - php7.0-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.0-cli  # Sapi
-        - php7.0-tidy # Native extension
-        - php7.0-apcu # Pecl extension
     - command: phpdismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0305_extensions.7.0.yml
+++ b/manala.php/tests/0305_extensions.7.0.yml
@@ -28,12 +28,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cli  # Sapi
+          - php7.0-tidy # Native extension
+          - php7.0-apcu # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.0-cli  # Sapi
-        - php7.0-tidy # Native extension
-        - php7.0-apcu # Pecl extension
     - command: phpdismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0306_extensions.7.1.yml
+++ b/manala.php/tests/0306_extensions.7.1.yml
@@ -27,12 +27,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.1-cli  # Sapi
+          - php7.1-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.1-cli  # Sapi
-        - php7.1-tidy # Native extension
-        - php-apcu    # Pecl extension
     - command: phpdismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0307_extensions.7.2.yml
+++ b/manala.php/tests/0307_extensions.7.2.yml
@@ -27,12 +27,11 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-cli  # Sapi
+          - php7.2-tidy # Native extension
+          - php-apcu    # Pecl extension
         install_recommends: false
-      with_items:
-        - php7.2-cli  # Sapi
-        - php7.2-tidy # Native extension
-        - php-apcu    # Pecl extension
     - command: phpdismod apcu
   roles:
     - manala.php

--- a/manala.php/tests/0400_configs_global.5.4.yml
+++ b/manala.php/tests/0400_configs_global.5.4.yml
@@ -21,11 +21,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cli
+          - php5-fpm
         install_recommends: false
-      with_items:
-        - php5-cli
-        - php5-fpm
     - copy:
         dest:    /etc/php5/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0501_configs.5.5.yml
+++ b/manala.php/tests/0501_configs.5.5.yml
@@ -30,11 +30,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cli
+          - php5-fpm
         install_recommends: false
-      with_items:
-        - php5-cli
-        - php5-fpm
     - copy:
         dest:    /etc/php5/cli/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0502_configs.5.6_dotdeb.yml
+++ b/manala.php/tests/0502_configs.5.6_dotdeb.yml
@@ -30,11 +30,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-cli
+          - php5-fpm
         install_recommends: false
-      with_items:
-        - php5-cli
-        - php5-fpm
     - copy:
         dest:    /etc/php5/cli/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0503_configs.5.6.yml
+++ b/manala.php/tests/0503_configs.5.6.yml
@@ -30,11 +30,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5.6-cli
+          - php5.6-fpm
         install_recommends: false
-      with_items:
-        - php5.6-cli
-        - php5.6-fpm
     - copy:
         dest:    /etc/php/5.6/cli/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0504_configs.7.0_dotdeb.yml
+++ b/manala.php/tests/0504_configs.7.0_dotdeb.yml
@@ -30,11 +30,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cli
+          - php7.0-fpm
         install_recommends: false
-      with_items:
-        - php7.0-cli
-        - php7.0-fpm
     - copy:
         dest:    /etc/php/7.0/cli/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0505_configs.7.0.yml
+++ b/manala.php/tests/0505_configs.7.0.yml
@@ -30,11 +30,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-cli
+          - php7.0-fpm
         install_recommends: false
-      with_items:
-        - php7.0-cli
-        - php7.0-fpm
     - copy:
         dest:    /etc/php/7.0/cli/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0506_configs.7.1.yml
+++ b/manala.php/tests/0506_configs.7.1.yml
@@ -30,11 +30,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.1-cli
+          - php7.1-fpm
         install_recommends: false
-      with_items:
-        - php7.1-cli
-        - php7.1-fpm
     - copy:
         dest:    /etc/php/7.1/cli/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0507_configs.7.2.yml
+++ b/manala.php/tests/0507_configs.7.2.yml
@@ -30,11 +30,10 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-cli
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-cli
-        - php7.2-fpm
     - copy:
         dest:    /etc/php/7.2/cli/conf.d/baz.ini
         content: |

--- a/manala.php/tests/0600_fpm_pools.5.4.yml
+++ b/manala.php/tests/0600_fpm_pools.5.4.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-fpm
         install_recommends: false
-      with_items:
-        - php5-fpm
     - copy:
         dest:    /etc/php5/fpm/pool.d/bar.conf
         content: |

--- a/manala.php/tests/0601_fpm_pools.5.5.yml
+++ b/manala.php/tests/0601_fpm_pools.5.5.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_55.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-fpm
         install_recommends: false
-      with_items:
-        - php5-fpm
     - copy:
         dest:    /etc/php5/fpm/pool.d/bar.conf
         content: |

--- a/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
+++ b/manala.php/tests/0602_fpm_pools.5.6_dotdeb.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb_wheezy_56.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5-fpm
         install_recommends: false
-      with_items:
-        - php5-fpm
     - copy:
         dest:    /etc/php5/fpm/pool.d/bar.conf
         content: |

--- a/manala.php/tests/0603_fpm_pools.5.6.yml
+++ b/manala.php/tests/0603_fpm_pools.5.6.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php5.6-fpm
         install_recommends: false
-      with_items:
-        - php5.6-fpm
     - copy:
         dest:    /etc/php/5.6/fpm/pool.d/bar.conf
         content: |

--- a/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
+++ b/manala.php/tests/0604_fpm_pools.7.0_dotdeb.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/dotdeb.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-fpm
         install_recommends: false
-      with_items:
-        - php7.0-fpm
     - copy:
         dest:    /etc/php/7.0/fpm/pool.d/bar.conf
         content: |

--- a/manala.php/tests/0605_fpm_pools.7.0.yml
+++ b/manala.php/tests/0605_fpm_pools.7.0.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.0-fpm
         install_recommends: false
-      with_items:
-        - php7.0-fpm
     - copy:
         dest:    /etc/php/7.0/fpm/pool.d/bar.conf
         content: |

--- a/manala.php/tests/0606_fpm_pools.7.1.yml
+++ b/manala.php/tests/0606_fpm_pools.7.1.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.1-fpm
         install_recommends: false
-      with_items:
-        - php7.1-fpm
     - copy:
         dest:    /etc/php/7.1/fpm/pool.d/bar.conf
         content: |

--- a/manala.php/tests/0607_fpm_pools.7.2.yml
+++ b/manala.php/tests/0607_fpm_pools.7.2.yml
@@ -27,10 +27,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - copy:
         dest:    /etc/php/7.2/fpm/pool.d/bar.conf
         content: |

--- a/manala.phpmyadmin/CHANGELOG.md
+++ b/manala.phpmyadmin/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-08
 ### Added

--- a/manala.phpmyadmin/tasks/install.yml
+++ b/manala.phpmyadmin/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_phpmyadmin_install_packages|default(manala_phpmyadmin_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_phpmyadmin_install_packages|default(manala_phpmyadmin_install_packages_default, True) }}"

--- a/manala.phpmyadmin/tests/0100_install.php_5.6.yml
+++ b/manala.phpmyadmin/tests/0100_install.php_5.6.yml
@@ -9,10 +9,9 @@
     - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
-        package: "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin

--- a/manala.phpmyadmin/tests/0101_install.php_7.2.yml
+++ b/manala.phpmyadmin/tests/0101_install.php_7.2.yml
@@ -6,10 +6,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin

--- a/manala.phpmyadmin/tests/0200_configs.php_5.6.yml
+++ b/manala.phpmyadmin/tests/0200_configs.php_5.6.yml
@@ -19,10 +19,9 @@
     - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
-        package: "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin

--- a/manala.phpmyadmin/tests/0201_configs.php_7.2.yml
+++ b/manala.phpmyadmin/tests/0201_configs.php_7.2.yml
@@ -16,10 +16,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpmyadmin

--- a/manala.phppgadmin/CHANGELOG.md
+++ b/manala.phppgadmin/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-08
 ### Added

--- a/manala.phppgadmin/tasks/install.yml
+++ b/manala.phppgadmin/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_phppgadmin_install_packages|default(manala_phppgadmin_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_phppgadmin_install_packages|default(manala_phppgadmin_install_packages_default, True) }}"

--- a/manala.phppgadmin/tests/0100_install.php_5.6.yml
+++ b/manala.phppgadmin/tests/0100_install.php_5.6.yml
@@ -9,10 +9,9 @@
     - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
-        package: "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin

--- a/manala.phppgadmin/tests/0101_install.php_7.2.yml
+++ b/manala.phppgadmin/tests/0101_install.php_7.2.yml
@@ -6,10 +6,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin

--- a/manala.phppgadmin/tests/0200_configs.php_5.6.yml
+++ b/manala.phppgadmin/tests/0200_configs.php_5.6.yml
@@ -19,10 +19,9 @@
     - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
-        package: "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin

--- a/manala.phppgadmin/tests/0201_configs.php_7.2.yml
+++ b/manala.phppgadmin/tests/0201_configs.php_7.2.yml
@@ -16,10 +16,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phppgadmin

--- a/manala.phpredisadmin/tasks/install.yml
+++ b/manala.phpredisadmin/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_phpredisadmin_install_packages|default(manala_phpredisadmin_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_phpredisadmin_install_packages|default(manala_phpredisadmin_install_packages_default, True) }}"

--- a/manala.phpredisadmin/tests/0100_install.php_5.6.yml
+++ b/manala.phpredisadmin/tests/0100_install.php_5.6.yml
@@ -9,10 +9,9 @@
     - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
-        package: "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin

--- a/manala.phpredisadmin/tests/0101_install.php_7.2.yml
+++ b/manala.phpredisadmin/tests/0101_install.php_7.2.yml
@@ -6,10 +6,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin

--- a/manala.phpredisadmin/tests/0200_configs.php_5.6.yml
+++ b/manala.phpredisadmin/tests/0200_configs.php_5.6.yml
@@ -18,10 +18,9 @@
     - import_tasks: pre_tasks/sury_php.yml
       when: ansible_distribution_release != 'wheezy'
     - apt:
-        package: "{{ item }}"
+        name:
+          - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
         install_recommends: false
-      with_items:
-        - "{{ (ansible_distribution_release == 'wheezy')|ternary('php5-fpm','php5.6-fpm') }}"
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin

--- a/manala.phpredisadmin/tests/0201_configs.php_7.2.yml
+++ b/manala.phpredisadmin/tests/0201_configs.php_7.2.yml
@@ -15,10 +15,9 @@
   pre_tasks:
     - import_tasks: pre_tasks/sury_php.yml
     - apt:
-        package: "{{ item }}"
+        name:
+          - php7.2-fpm
         install_recommends: false
-      with_items:
-        - php7.2-fpm
     - import_tasks: pre_tasks/manala.yml
   roles:
     - manala.phpredisadmin

--- a/manala.postgresql/CHANGELOG.md
+++ b/manala.postgresql/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Replace deprecated jinja tests used as filters
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.postgresql/tasks/install.yml
+++ b/manala.postgresql/tasks/install.yml
@@ -2,19 +2,17 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{
+      manala_postgresql_install_packages|default(manala_postgresql_install_packages_default, True)
+      + (
+        (manala_postgresql_databases|length > 0)
+        or (manala_postgresql_privileges|length > 0)
+        or (manala_postgresql_roles|length > 0)
+      )|ternary(
+        ['python-psycopg2'],
+        []
+      )
+    }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{
-    manala_postgresql_install_packages|default(manala_postgresql_install_packages_default, True)
-    + (
-      (manala_postgresql_databases|length > 0)
-      or (manala_postgresql_privileges|length > 0)
-      or (manala_postgresql_roles|length > 0)
-    )|ternary(
-      ['python-psycopg2'],
-      []
-    )
-  }}"

--- a/manala.proftpd/CHANGELOG.md
+++ b/manala.proftpd/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.proftpd/tasks/install.yml
+++ b/manala.proftpd/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_proftpd_install_packages|default(manala_proftpd_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_proftpd_install_packages|default(manala_proftpd_install_packages_default, True) }}"

--- a/manala.proxmox/CHANGELOG.md
+++ b/manala.proxmox/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.proxmox/tasks/install.yml
+++ b/manala.proxmox/tasks/install.yml
@@ -2,15 +2,13 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name:  "{{
+      []
+      + (manala_proxmox_instances|length > 0)|ternary(
+        ['python-proxmoxer'],
+        []
+      )
+    }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{
-    []
-    + (manala_proxmox_instances|length > 0)|ternary(
-      ['python-proxmoxer'],
-      []
-    )
-  }}"

--- a/manala.redis/CHANGELOG.md
+++ b/manala.redis/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Replace deprecated jinja tests used as filters
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.redis/tasks/install.yml
+++ b/manala.redis/tasks/install.yml
@@ -2,12 +2,10 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_redis_install_packages|default(manala_redis_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_redis_install_packages|default(manala_redis_install_packages_default, True) }}"
 
 - name: install > Version
   shell: redis-server -v | sed 's/[^0-9.]*\([0-9.]*\).*/\1/'

--- a/manala.rsyslog/CHANGELOG.md
+++ b/manala.rsyslog/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.rsyslog/tasks/install.yml
+++ b/manala.rsyslog/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_rsyslog_install_packages|default(manala_rsyslog_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_rsyslog_install_packages|default(manala_rsyslog_install_packages_default, True) }}"

--- a/manala.rtail/CHANGELOG.md
+++ b/manala.rtail/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.rtail/tasks/install.yml
+++ b/manala.rtail/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_rtail_install_packages|default(manala_rtail_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_rtail_install_packages|default(manala_rtail_install_packages_default, True) }}"

--- a/manala.rtail/tests/0100_install.yml
+++ b/manala.rtail/tests/0100_install.yml
@@ -14,11 +14,10 @@
           Pin:          origin debian.manala.io
           Pin-Priority: 900
     - apt:
-        name:  "{{ item }}"
+        name:
+          - nodejs
+          - nodejs-legacy
         install_recommends: false
-      with_items:
-        - nodejs
-        - nodejs-legacy
   roles:
     - manala.rtail
   post_tasks:

--- a/manala.rtail/tests/0200_config.yml
+++ b/manala.rtail/tests/0200_config.yml
@@ -17,11 +17,10 @@
           Pin:          origin debian.manala.io
           Pin-Priority: 900
     - apt:
-        name:  "{{ item }}"
+        name:
+          - nodejs
+          - nodejs-legacy
         install_recommends: false
-      with_items:
-        - nodejs
-        - nodejs-legacy
   roles:
     - manala.rtail
   post_tasks:

--- a/manala.rtail/tests/0300_services.yml
+++ b/manala.rtail/tests/0300_services.yml
@@ -14,11 +14,10 @@
           Pin:          origin debian.manala.io
           Pin-Priority: 900
     - apt:
-        name:  "{{ item }}"
+        name:
+          - nodejs
+          - nodejs-legacy
         install_recommends: false
-      with_items:
-        - nodejs
-        - nodejs-legacy
   roles:
     - manala.rtail
   post_tasks:

--- a/manala.sensu/CHANGELOG.md
+++ b/manala.sensu/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.sensu/tasks/install.yml
+++ b/manala.sensu/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_sensu_install_packages|default(manala_sensu_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_sensu_install_packages|default(manala_sensu_install_packages_default, True) }}"

--- a/manala.shorewall/CHANGELOG.md
+++ b/manala.shorewall/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.shorewall/tasks/install.yml
+++ b/manala.shorewall/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_shorewall_install_packages|default(manala_shorewall_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_shorewall_install_packages|default(manala_shorewall_install_packages_default, True) }}"

--- a/manala.sqlite/CHANGELOG.md
+++ b/manala.sqlite/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.sqlite/tasks/install.yml
+++ b/manala.sqlite/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_sqlite_install_packages|default(manala_sqlite_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_sqlite_install_packages|default(manala_sqlite_install_packages_default, True) }}"

--- a/manala.ssh/CHANGELOG.md
+++ b/manala.ssh/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.ssh/tasks/install.yml
+++ b/manala.ssh/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_ssh_install_packages|default(manala_ssh_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_ssh_install_packages|default(manala_ssh_install_packages_default, True) }}"

--- a/manala.sudo/CHANGELOG.md
+++ b/manala.sudo/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.sudo/tasks/install.yml
+++ b/manala.sudo/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_sudo_install_packages|default(manala_sudo_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_sudo_install_packages|default(manala_sudo_install_packages_default, True) }}"

--- a/manala.supervisor/CHANGELOG.md
+++ b/manala.supervisor/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2018-03-28
 ### Added

--- a/manala.supervisor/tasks/install.yml
+++ b/manala.supervisor/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_supervisor_install_packages|default(manala_supervisor_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_supervisor_install_packages|default(manala_supervisor_install_packages_default, True) }}"

--- a/manala.telegraf/CHANGELOG.md
+++ b/manala.telegraf/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.telegraf/tasks/install.yml
+++ b/manala.telegraf/tasks/install.yml
@@ -2,10 +2,8 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_telegraf_install_packages|default(manala_telegraf_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_telegraf_install_packages|default(manala_telegraf_install_packages_default, True) }}"
   ignore_errors: "{{ ansible_check_mode }}"

--- a/manala.varnish/CHANGELOG.md
+++ b/manala.varnish/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.varnish/tasks/install.yml
+++ b/manala.varnish/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_varnish_install_packages|default(manala_varnish_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_varnish_install_packages|default(manala_varnish_install_packages_default, True) }}"

--- a/manala.vault/CHANGELOG.md
+++ b/manala.vault/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.vault/tasks/install.yml
+++ b/manala.vault/tasks/install.yml
@@ -2,10 +2,8 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_vault_install_packages|default(manala_vault_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_vault_install_packages|default(manala_vault_install_packages_default, True) }}"
   ignore_errors: "{{ ansible_check_mode }}"

--- a/manala.vim/CHANGELOG.md
+++ b/manala.vim/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.vim/tasks/install.yml
+++ b/manala.vim/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_vim_install_packages|default(manala_vim_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_vim_install_packages|default(manala_vim_install_packages_default, True) }}"

--- a/manala.yarn/CHANGELOG.md
+++ b/manala.yarn/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.2] - 2017-12-06
 ### Added

--- a/manala.yarn/tasks/install.yml
+++ b/manala.yarn/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_yarn_install_packages|default(manala_yarn_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_yarn_install_packages|default(manala_yarn_install_packages_default, True) }}"

--- a/manala.zsh/CHANGELOG.md
+++ b/manala.zsh/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Replace deprecated uses of "include"
+- Pass apt module packages list directly to the `name` option
 
 ## [1.0.1] - 2017-12-06
 ### Added

--- a/manala.zsh/tasks/install.yml
+++ b/manala.zsh/tasks/install.yml
@@ -2,9 +2,7 @@
 
 - name: install > Packages
   apt:
-    name:  "{{ item }}"
-    state: present
+    name: "{{ manala_zsh_install_packages|default(manala_zsh_install_packages_default, True) }}"
     install_recommends: false
     update_cache:       true
     cache_valid_time:   3600
-  with_items: "{{ manala_zsh_install_packages|default(manala_zsh_install_packages_default, True) }}"


### PR DESCRIPTION
We missed the moment where using `with_items` in apt/yum modules became obsolete in favor of passing a name list...

See: https://github.com/ansible/ansible/commit/8e56133b3d28e0871ea226698173d699ffdc63e2

Before:
```
- apt:
   name:  "{{ item }}"
   with_items:	
     - foo
     - bar
```

After
```
- apt:
   name:
     - foo
     - bar
```