### PR TITLE
[Proxmox] Loop over instances management until its ready

### DIFF
--- a/manala.proxmox/CHANGELOG.md
+++ b/manala.proxmox/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Loop over instances management until its ready
+
 ### Changed
 - Replace deprecated uses of "include"
 

--- a/manala.proxmox/tasks/instances.yml
+++ b/manala.proxmox/tasks/instances.yml
@@ -31,3 +31,7 @@
     validate_certs: "{{ item.validate_certs|default(manala_proxmox_instances_defaults.validate_certs|default(omit)) }}"
     vmid:           "{{ item.vmid|default(omit) }}"
   with_items: "{{ manala_proxmox_instances }}"
+  register: __manala_proxmox_instances_result
+  until: __manala_proxmox_instances_result.msg.find('Vmid could not be fetched') == -1
+  retries: 12
+  delay: 1


### PR DESCRIPTION
This helps in situations where an instance must be started right after being created, but because creation takes few seconds, we have to loop until it has been created.

```
manala_proxmox_instances:
    - hostname: foo
      disk: 20
      ostemplate: local:vztmpl/template.tar.gz
    # At this point, we have to wait for the instance to be created, by looping over and over, until its ready
    - hostname: foo
      state: started
```