### PR TITLE
[Files] Replace link_file "touch" step by a combination of an unforce…

### DIFF
--- a/manala.files/CHANGELOG.md
+++ b/manala.files/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Replace link_file "touch" step by a combination of an unforced empty copy and a classic file module. This offers the same behaviour to the linked file, but don't report it as changed each time the role is played
+
 ### Changed
 - Replace deprecated uses of "include"
 

--- a/manala.files/tasks/attributes/link_file.yml
+++ b/manala.files/tasks/attributes/link_file.yml
@@ -5,6 +5,16 @@
     - manala_files
   block:
 
+    - name: attributes/link_file > Create "{{ item.src }}"
+      copy:
+        dest:    "{{ item.src }}"
+        content: ""
+        force:   false
+        follow:  "{{ item.follow|default(omit) }}"
+        owner:   "{{ item.user|default(omit) }}"
+        group:   "{{ item.group|default(omit) }}"
+        mode:    "{{ item.mode|default(omit) }}"
+
     - name: attributes/link_file > File "{{ item.src }}"
       file:
         path:    "{{ item.src }}"
@@ -14,7 +24,7 @@
         owner:   "{{ item.user|default(omit) }}"
         group:   "{{ item.group|default(omit) }}"
         mode:    "{{ item.mode|default(omit) }}"
-        state:   touch
+        state:   file
 
     - name: attributes/link_file > Link "{{ item.path }}"
       file:


### PR DESCRIPTION
…d empty copy and a classic file module. This offers the same behaviour to the linked file, but don't report it as changed each time the role is played.