### PR TITLE
[Php] Give opportunity to specify certificates validation on application download

### DIFF
--- a/manala.php/CHANGELOG.md
+++ b/manala.php/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Replace deprecated jinja tests used as filters
 
+### Fixed
+- Give opportunity to specify certificates validation on application download
+
 ## [1.0.8] - 2018-03-28
 ### Changed
 - Provide "cli" and "fpm" as default sapis

--- a/manala.php/tasks/applications.yml
+++ b/manala.php/tasks/applications.yml
@@ -5,6 +5,7 @@
     url:  "{{ item.source }}"
     dest: "{{ manala_php_applications_dir }}/{{ item.application ~ item.version|ternary('_' ~ item.version, '') }}"
     mode: 0755
+    validate_certs: "{{ item.validate_certs|default(omit) }}"
   with_manala_php_applications:
     - "{{ manala_php_applications }}"
     - "{{ manala_php_applications_patterns }}"

--- a/manala.php/vars/main.yml
+++ b/manala.php/vars/main.yml
@@ -359,6 +359,7 @@ manala_php_applications_patterns:
   phpunit:
     source:         https://phar.phpunit.de/phpunit.phar
     source_version: https://phar.phpunit.de/phpunit-{version}.phar
+    validate_certs: "{{ (ansible_distribution_release == 'wheezy')|ternary(false, true) }}"
   php-cs-fixer:
     source: http://get.sensiolabs.org/php-cs-fixer.phar
   couscous:


### PR DESCRIPTION
On old distributions (debian wheezy, for instance) the python version is too old to validate some SSL certificates.
This pr allows to conditionnaly force/unforce such validation, on an application-basis. 