### PR TITLE
[All] Useless "playbook_dir" usage in documentation

### DIFF
--- a/manala.apparmor/README.md
+++ b/manala.apparmor/README.md
@@ -53,7 +53,7 @@ Using ansible galaxy requirements file:
   vars:
     manala_apparmor_configs:
       - file:     lxc/lxc-profile-a
-        template: "{{ playbook_dir }}/templates/lxc-default.j2"
+        template: lxc-default.j2
       - file:     lxc/lxc-old-profile
         state:    absent
 

--- a/manala.git/README.md
+++ b/manala.git/README.md
@@ -52,15 +52,7 @@ None
 
 The `manala_git_config_file` key allow you to specify the path to the config file.
 
-#### Example:
-
-```yaml
----
-
-manala_git_config_file: "{{ playbook_dir }}/templates/git/default.dev.j2"
-```
-
-The `manala_git_config_template` key will allow you to use differents main configuration templates. The role is shipped with basic templates :
+The `manala_git_config_template` key will allow you to use different main configuration templates. The role is shipped with basic templates :
 
 - base (Simple template with no default configuration)
 - dev (This configuration will provide options for Vagrant VM, like ohmyzsh)
@@ -68,6 +60,14 @@ The `manala_git_config_template` key will allow you to use differents main confi
 - prod (For production purpose. Light configuration template)
 
 GIT experienced users can provide their own custom template with the `manala_git_config_template` key.
+
+#### Example:
+
+```yaml
+---
+
+manala_git_config_template: config/default.dev.j2
+```
 
 The `manala_git_config` key allow to define git config keys like the following:
 

--- a/manala.gitlab/README.md
+++ b/manala.gitlab/README.md
@@ -53,9 +53,9 @@ manala_gitlab_version: 8.1.*
 manala_gitlab_configs_exclusive: true
 manala_gitlab_configs:
   - file:     gitlab-secrets.json
-    template: "{{ playbook_dir }}/templates/gitlab-secrets.json.j2"
+    template: gitlab-secrets.json.j2
   - file:     gitlab.rb
-    template: "{{ playbook_dir }}/templates/gitlab.rb.j2"
+    template: gitlab.rb.j2
 ```
 
 ## Example playbook

--- a/manala.grafana/README.md
+++ b/manala.grafana/README.md
@@ -85,7 +85,7 @@ manala_grafana_datasources:
 
 manala_grafana_dashboards_exclusive: true
 manala_grafana_dashboards:
-    - template: "{{ playbook_dir }}/templates/grafana/dashboards/system.json"
+    - template: grafana/dashboards/system.json
       inputs:
         - name:     "DS_TELEGRAF"
           pluginId: "influxdb"

--- a/manala.haproxy/README.md
+++ b/manala.haproxy/README.md
@@ -55,7 +55,7 @@ manala_haproxy_errorfiles:
   - name: 400.http
     template: errorfiles/400.http.j2
   - name: maintenance.http
-    template: "{{ playbook_dir ~ '/templates/haproxy/errorfiles/maintenance.http.j2' }}"
+    template: errorfiles/maintenance.http.j2
 ```
 
 Use default config template, and set/add custom parameters
@@ -87,7 +87,7 @@ manala_haproxy_config:
 Use custom config template
 
 ```yaml
-manala_haproxy_config_template: "{{ playbook_dir ~ '/templates/haproxy/haproxy.cfg.j2' }}"
+manala_haproxy_config_template: haproxy/haproxy.cfg.j2
 ```
 
 ## Example playbook

--- a/manala.maxscale/README.md
+++ b/manala.maxscale/README.md
@@ -59,7 +59,7 @@ Using ansible galaxy requirements file:
 
 ```yaml
 # Using a custom template
-manala_maxscale_config_template: "{{ playbook_dir ~ '/templates/maxscale/custom_template.j2' }}"
+manala_maxscale_config_template: maxscale/custom_template.j2
 
 manala_maxscale_config:
   - maxscale:

--- a/manala.motd/README.md
+++ b/manala.motd/README.md
@@ -36,10 +36,10 @@ None
 
 ## Role Variables
 
-|Name|Default|Type|Description|
-|----|----|-----------|-------|
-`manala_motd_template`|template/manala.j2|String (path)|Path to custom motd.
-`manala_motd_message`|California 1993|String|A custom message
+| Name                   | Default           | Type   | Description   |
+| ---------------------- | ----------------- | ------ | ------------- |
+| `manala_motd_template` | template/empty.j2 | String | Template path |
+| `manala_motd_message`  | ~                 | String | Message       |
 
 ### Configuration example
 
@@ -49,7 +49,7 @@ Use predefined type (manala|cow|turkey|stegosaurus) with custom message:
 ---
 
 manala_motd_template: template/turkey.j2
-manala_motd_message:  "My awesome message"
+manala_motd_message:  My awesome message
 ```
 
 Use custom template:
@@ -57,7 +57,7 @@ Use custom template:
 ```yaml
 ---
 
-manala_motd_template:  "{{ playbook_dir ~ '/templates/motd.j2' }}"
+manala_motd_template: motd/motd.j2
 ```
 
 ## Example playbook

--- a/manala.mysql/README.md
+++ b/manala.mysql/README.md
@@ -51,7 +51,7 @@ Using ansible galaxy requirements file:
 
 ```yaml
 # use a default custom template
-manala_mysql_configs_template: "{{ playbook_dir ~ '/templates/mysql/custom_template.j2' }}"
+manala_mysql_configs_template: mysql/custom_template.j2
 
 # clean configs directory
 manala_mysql_configs_exclusive: true

--- a/manala.postgresql/README.md
+++ b/manala.postgresql/README.md
@@ -57,7 +57,7 @@ manala_postgresql_version: 9.4
 manala_postgresql_config_template: config/default.dev.j2
 manala_postgresql_config:
   - max_connections: 123
-manala_postgresql_config_hba_template: "{{ playbook_dir ~ '/templates/pg_hba.j2' }}"
+manala_postgresql_config_hba_template: config/hba/default.dev.j2
 manala_postgresql_config_hba:
   - local   all             postgres                                peer
   - local   all             all                                     peer

--- a/manala.telegraf/README.md
+++ b/manala.telegraf/README.md
@@ -71,7 +71,7 @@ manala_telegraf_configs:
     template: configs/input_cpu.conf.j2
 
   - file:     input_custom.conf
-    template: "{{ playbook_dir }}/templates/telegraf/input_custom.conf.j2"
+    template: telegraf/input_custom.conf.j2
 ```
 
 ## Example playbook

--- a/manala.vault/README.md
+++ b/manala.vault/README.md
@@ -54,7 +54,7 @@ Using ansible galaxy requirements file:
 ## Configuration example
 
 ```yaml
-manala_vault_config_template: "{{ playbook_dir }}/templates/vault/vault/config.hcl.j2"
+manala_vault_config_template: vault/vault/config.hcl.j2
 ```
 
 ## Example playbook


### PR DESCRIPTION
No need to use `playbook_dir` as its part of templates search path (see: https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/user_guide/playbook_pathing.rst)

Fix #120

Ping @yvalentin