### PR TITLE
[All] Introduce auto release

### DIFF
--- a/.manala/make/Makefile
+++ b/.manala/make/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint test split sync
+.PHONY: lint test release sync
 
 ##########
 # Manala #
@@ -77,17 +77,18 @@ TEST_HELP += $(call help,test.diff,Test roles - Diff)
 test.diff: ROLES = $(ROLES_DIFF)
 test.diff: test
 
-#########
-# Split #
-#########
+###########
+# Release #
+###########
 
-MANALA_HELP += $(SPLIT_HELP)\n
+MANALA_HELP += $(RELEASE_HELP)\n
 
-SPLIT_HELP = \
-	$(call help_section,Split) \
-	$(call help,split,Split git repositories)
+RELEASE_HELP = \
+	$(call help_section,Release) \
+	$(call help,release,Release ansible roles)
 
-split:
+release:
+	$(call confirm,Please confirm release of *ALL* ansible roles)
 	$(call gitsplit)
 
 ########

--- a/README.md
+++ b/README.md
@@ -81,3 +81,17 @@
 | [vim](https://github.com/manala/ansible-role-vim) | This role will deal with the setup and configuration of Vim. | [![Build Status](https://travis-ci.org/manala/ansible-role-vim.svg?branch=master)](https://travis-ci.org/manala/ansible-role-vim) | [![Latest Stable Version](https://img.shields.io/github/release/manala/ansible-role-vim.svg)](https://img.shields.io/github/release/manala/ansible-role-vim.svg) |
 | [yarn](https://github.com/manala/ansible-role-yarn) | This role will deal with the setup of [Yarn](https://yarnpkg.com/). | [![Build Status](https://travis-ci.org/manala/ansible-role-yarn.svg?branch=master)](https://travis-ci.org/manala/ansible-role-yarn) | [![Latest Stable Version](https://img.shields.io/github/release/manala/ansible-role-yarn.svg)](https://img.shields.io/github/release/manala/ansible-role-yarn.svg) |
 | [zsh](https://github.com/manala/ansible-role-zsh) | This role will deal with the setup of Zsh. | [![Build Status](https://travis-ci.org/manala/ansible-role-zsh.svg?branch=master)](https://travis-ci.org/manala/ansible-role-zsh) | [![Latest Stable Version](https://img.shields.io/github/release/manala/ansible-role-zsh.svg)](https://img.shields.io/github/release/manala/ansible-role-zsh.svg) |
+
+## Release
+
+```
+make release
+```
+
+### Set Chandler github api token
+
+```
+export CHANDLER_GITHUB_API_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+travis login
+travis repos --owner manala --active --no-interactive --match "manala/ansible-role-*" | xargs -n1 travis env set CHANDLER_GITHUB_API_TOKEN $CHANDLER_GITHUB_API_TOKEN --private --repo
+```

--- a/manala.accounts/.travis.yml
+++ b/manala.accounts/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.alternatives/.travis.yml
+++ b/manala.alternatives/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.ansible-galaxy/.travis.yml
+++ b/manala.ansible-galaxy/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.ansible/.travis.yml
+++ b/manala.ansible/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.apparmor/.travis.yml
+++ b/manala.apparmor/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.apt/.travis.yml
+++ b/manala.apt/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.aptly/.travis.yml
+++ b/manala.aptly/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.backup-manager/.travis.yml
+++ b/manala.backup-manager/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.beanstalkd/.travis.yml
+++ b/manala.beanstalkd/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.bind/.travis.yml
+++ b/manala.bind/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.cloud-init/.travis.yml
+++ b/manala.cloud-init/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.composer/.travis.yml
+++ b/manala.composer/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.cron/.travis.yml
+++ b/manala.cron/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.deploy/.travis.yml
+++ b/manala.deploy/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.dhcp/.travis.yml
+++ b/manala.dhcp/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.dnsmasq/.travis.yml
+++ b/manala.dnsmasq/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.docker/.travis.yml
+++ b/manala.docker/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.elasticsearch/.travis.yml
+++ b/manala.elasticsearch/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.environment/.travis.yml
+++ b/manala.environment/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.fail2ban/.travis.yml
+++ b/manala.fail2ban/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.files/.travis.yml
+++ b/manala.files/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.git/.travis.yml
+++ b/manala.git/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.gitlab/.travis.yml
+++ b/manala.gitlab/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.grafana/.travis.yml
+++ b/manala.grafana/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.haproxy/.travis.yml
+++ b/manala.haproxy/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.heka/.travis.yml
+++ b/manala.heka/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.hugo/.travis.yml
+++ b/manala.hugo/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.influxdb/.travis.yml
+++ b/manala.influxdb/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.java/.travis.yml
+++ b/manala.java/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.keepalived/.travis.yml
+++ b/manala.keepalived/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.kernel/.travis.yml
+++ b/manala.kernel/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.locales/.travis.yml
+++ b/manala.locales/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.logentries/.travis.yml
+++ b/manala.logentries/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.logrotate/.travis.yml
+++ b/manala.logrotate/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.mailhog/.travis.yml
+++ b/manala.mailhog/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.make/.travis.yml
+++ b/manala.make/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.maxscale/.travis.yml
+++ b/manala.maxscale/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.merge/.travis.yml
+++ b/manala.merge/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.mongo-express/.travis.yml
+++ b/manala.mongo-express/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.mongodb/.travis.yml
+++ b/manala.mongodb/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.motd/.travis.yml
+++ b/manala.motd/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.mount/.travis.yml
+++ b/manala.mount/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.mysql/.travis.yml
+++ b/manala.mysql/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.network/.travis.yml
+++ b/manala.network/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.nginx/.travis.yml
+++ b/manala.nginx/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.ngrok/.travis.yml
+++ b/manala.ngrok/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.nodejs/.travis.yml
+++ b/manala.nodejs/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.npm/.travis.yml
+++ b/manala.npm/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.ntp/.travis.yml
+++ b/manala.ntp/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.oauth2-proxy/.travis.yml
+++ b/manala.oauth2-proxy/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.ohmyzsh/.travis.yml
+++ b/manala.ohmyzsh/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.opcache-dashboard/.travis.yml
+++ b/manala.opcache-dashboard/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.pam-ssh-agent-auth/.travis.yml
+++ b/manala.pam-ssh-agent-auth/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.phantomjs/.travis.yml
+++ b/manala.phantomjs/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.php/.travis.yml
+++ b/manala.php/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.phpmyadmin/.travis.yml
+++ b/manala.phpmyadmin/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.phppgadmin/.travis.yml
+++ b/manala.phppgadmin/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.phpredisadmin/.travis.yml
+++ b/manala.phpredisadmin/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.postgresql/.travis.yml
+++ b/manala.postgresql/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.proftpd/.travis.yml
+++ b/manala.proftpd/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.proxmox/.travis.yml
+++ b/manala.proxmox/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.redis/.travis.yml
+++ b/manala.redis/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.rsyslog/.travis.yml
+++ b/manala.rsyslog/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.rtail/.travis.yml
+++ b/manala.rtail/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.sensu/.travis.yml
+++ b/manala.sensu/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.shorewall/.travis.yml
+++ b/manala.shorewall/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.skeleton/.travis.yml
+++ b/manala.skeleton/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.sqlite/.travis.yml
+++ b/manala.sqlite/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.ssh/.travis.yml
+++ b/manala.ssh/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.sudo/.travis.yml
+++ b/manala.sudo/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.supervisor/.travis.yml
+++ b/manala.supervisor/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.systemd/.travis.yml
+++ b/manala.systemd/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.telegraf/.travis.yml
+++ b/manala.telegraf/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.timezone/.travis.yml
+++ b/manala.timezone/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.varnish/.travis.yml
+++ b/manala.varnish/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.vault/.travis.yml
+++ b/manala.vault/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.vim/.travis.yml
+++ b/manala.vim/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.yarn/.travis.yml
+++ b/manala.yarn/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/manala.zsh/.travis.yml
+++ b/manala.zsh/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make lint
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:


### PR DESCRIPTION
- [x] Replace `make split` by `make release`. From now, the single repo is the virtual master branch for all sub repos. Once it's git-splitted, if tests has passed, every updated sub repo is tagged from master, using release note from last changelog entry.
- [x] Use [chandler](https://github.com/mattbrictson/chandler/releases) to ensure github/changelog synchronization
- [x] Use travis build stages (beta) to push release if tests passed