### PR TITLE
Create InfluxDB admins and use authentication

### DIFF
--- a/manala.influxdb/README.md
+++ b/manala.influxdb/README.md
@@ -47,16 +47,17 @@ Using ansible galaxy requirements file:
 
 ## Role Variables
 
-| Name                                       | Default                       | Type   | Description                                    |
-| ------------------------------------------ | ----------------------------- | ------ | ---------------------------------------------- |
-| `manala_influxdb_install_packages`         | ~                             | Array  | Dependency packages to install                 |
-| `manala_influxdb_install_packages_default` | ['influxdb']                  | Array  | Default dependency packages to install         |
-| `manala_influxdb_databases`                | []                            | Array  | Databases                                      |
-| `manala_influxdb_users`                    | []                            | Array  | Users                                          |
-| `manala_influxdb_privileges`               | []                            | Array  | Privileges                                     |
-| `manala_influxdb_config`                   | []                            | Array  | Configuration                                  |
-| `manala_influxdb_config_file`              | '/etc/influxdb/influxdb.conf' | String | Configuration file path                        |
-| `manala_influxdb_config_template`          | 'config/base.conf.j2'         | String | Configuration template path                    |
+| Name                                       | Default                       | Type       | Description                                    |
+| ------------------------------------------ | ----------------------------- | ------     | ---------------------------------------------- |
+| `manala_influxdb_install_packages`         | ~                             | Array      | Dependency packages to install                 |
+| `manala_influxdb_install_packages_default` | ['influxdb']                  | Array      | Default dependency packages to install         |
+| `manala_influxdb_databases`                | []                            | Array      | Databases                                      |
+| `manala_influxdb_admins`                   | {}                            | Dictionary | Database to admin mapping                      |
+| `manala_influxdb_users`                    | []                            | Array      | Users                                          |
+| `manala_influxdb_privileges`               | []                            | Array      | Privileges                                     |
+| `manala_influxdb_config`                   | []                            | Array      | Configuration                                  |
+| `manala_influxdb_config_file`              | '/etc/influxdb/influxdb.conf' | String     | Configuration file path                        |
+| `manala_influxdb_config_template`          | 'config/base.conf.j2'         | String     | Configuration template path                    |
 
 ### Configuration example
 
@@ -64,6 +65,11 @@ Using ansible galaxy requirements file:
 ############
 # InfluxDB #
 ############
+
+manala_influxdb_admins:
+  my_db:
+    name:     admin
+    password: admin_password
 
 manala_influxdb_databases:
   - my_db

--- a/manala.influxdb/defaults/main.yml
+++ b/manala.influxdb/defaults/main.yml
@@ -9,6 +9,7 @@ manala_influxdb_install_packages_default:
 manala_influxdb_databases:  []
 
 # Users
+manala_influxdb_admins: {}
 manala_influxdb_users: []
 
 # Privileges

--- a/manala.influxdb/tasks/admins.yml
+++ b/manala.influxdb/tasks/admins.yml
@@ -1,0 +1,11 @@
+---
+
+- name: users > Create Influx admins
+  command: >
+    {{ manala_influxdb_influx_bin }}
+    -username '{{ item.value.name }}'
+    -password '{{ item.value.password }}'
+    -database '{{ item.key }}'
+    -execute "CREATE USER {{ item.value.name }} WITH PASSWORD '{{ item.value.password }}' WITH ALL PRIVILEGES"
+  with_dict: "{{ manala_influxdb_admins }}"
+  changed_when: false

--- a/manala.influxdb/tasks/databases.yml
+++ b/manala.influxdb/tasks/databases.yml
@@ -1,6 +1,12 @@
 ---
 
 - name: databases > Create Influx databases
-  command: "{{ manala_influxdb_influx_bin }} -execute 'CREATE DATABASE \"{{ item }}\"'"
+  command: >
+    {{ manala_influxdb_influx_bin }}
+    {% if item in manala_influxdb_admins %}
+      -username '{{ manala_influxdb_admins[item].name }}'
+      -password '{{ manala_influxdb_admins[item].password }}'
+    {% endif %}
+    -execute 'CREATE DATABASE "{{ item }}"'
   with_items: "{{ manala_influxdb_databases }}"
   changed_when: false

--- a/manala.influxdb/tasks/main.yml
+++ b/manala.influxdb/tasks/main.yml
@@ -17,6 +17,11 @@
     - manala_influxdb.services
     - manala.services
 
+# Admins
+- import_tasks: admins.yml
+  tags:
+    - manala_influxdb
+
 # Databases
 - import_tasks: databases.yml
   tags:

--- a/manala.influxdb/tasks/privileges.yml
+++ b/manala.influxdb/tasks/privileges.yml
@@ -1,6 +1,12 @@
 ---
 
 - name: privileges > Setup Influx privileges
-  command: "{{ manala_influxdb_influx_bin }} -execute 'GRANT {{ item.grant }} ON \"{{ item.database }}\" TO \"{{ item.user }}\"'"
+  command: >
+    {{ manala_influxdb_influx_bin }}
+    {% if item.database in manala_influxdb_admins %}
+      -username '{{ manala_influxdb_admins[item.database].name }}'
+      -password '{{ manala_influxdb_admins[item.database].password }}'
+    {% endif %}
+    -execute 'GRANT {{ item.grant }} ON "{{ item.database }}" TO "{{ item.user }}"'
   with_items: "{{ manala_influxdb_privileges }}"
   changed_when: false

--- a/manala.influxdb/tasks/users.yml
+++ b/manala.influxdb/tasks/users.yml
@@ -1,6 +1,13 @@
 ---
 
 - name: users > Create Influx users
-  command: "{{ manala_influxdb_influx_bin }} -database '{{ item.database }}' -execute \"CREATE USER {{ item.name }} WITH PASSWORD '{{ item.password }}'\""
+  command: >
+    {{ manala_influxdb_influx_bin }}
+    {% if item.database in manala_influxdb_admins %}
+      -username '{{ manala_influxdb_admins[item.database].name }}'
+      -password '{{ manala_influxdb_admins[item.database].password }}'
+    {% endif %}
+    -database '{{ item.database }}'
+    -execute "CREATE USER {{ item.name }} WITH PASSWORD '{{ item.password }}'"
   with_items: "{{ manala_influxdb_users }}"
   changed_when: false


### PR DESCRIPTION
This enables the use of `auth-enabled=true` for InfluxDB HTTP(S) API

We want to avoid having to change our Ansible files when bootstrapping
InfluxDB authentication so that setup works in idempotent way even
with auth-enabled=true.

To achieve this, admins are created first with one admin per database.
We rely on InfluxDB behaviour with auth-enabled:

> If you enable authentication and have no users, InfluxDB will not
> enforce authentication and will only accept the query that creates a
> new admin user.

(see https://docs.influxdata.com/influxdb/v1.6/administration/authentication_and_authorization/)

Once admins are created, their credentials are used for all other
influx calls (databases/users/privileges).