### PR TITLE
[All] Python 3 compatibility

### DIFF
--- a/manala.accounts/CHANGELOG.md
+++ b/manala.accounts/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Changed

--- a/manala.accounts/lookup_plugins/manala_accounts_users_authorized_keys.py
+++ b/manala.accounts/lookup_plugins/manala_accounts_users_authorized_keys.py
@@ -4,6 +4,7 @@ __metaclass__ = type
 import os.path
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -19,24 +20,24 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Expect a dict')
 
             # Check index key
-            if not term.has_key('user'):
+            if 'user' not in term:
                 raise AnsibleError('Expect "user" key')
 
             items = []
 
-            if term.has_key('authorized_keys'):
+            if 'authorized_keys' in term:
                 item = {
                     'user':            term.get('user'),
                     'authorized_keys': '\n'.join(term.get('authorized_keys'))
                 }
 
                 # File
-                if term.has_key('authorized_keys_file') and term.get('authorized_keys_file'):
+                if 'authorized_keys_file' in term and term.get('authorized_keys_file'):
                     # Omit
                     if term.get('authorized_keys_file') == variables['omit']:
                         pass
                     # Path
-                    elif isinstance(term.get('authorized_keys_file'), basestring):
+                    elif isinstance(term.get('authorized_keys_file'), string_types):
                         # Absolute
                         if term.get('authorized_keys_file').startswith('/'):
                             item.update({

--- a/manala.ansible-galaxy/CHANGELOG.md
+++ b/manala.ansible-galaxy/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
+
+### Changed
+- Ignore SSL certificate validation errors on debian wheezy when using
+  official ansible galaxy bin (incompatible default python version)
 
 ## [1.0.3] - 2018-06-05
 ### Changed

--- a/manala.ansible-galaxy/lookup_plugins/manala_ansible_galaxy_roles.py
+++ b/manala.ansible-galaxy/lookup_plugins/manala_ansible_galaxy_roles.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -15,7 +16,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 items.append({
                     'src': term
                 })
@@ -26,7 +27,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('src'):
+                if 'src' not in term:
                     raise AnsibleError('Expect "src" key')
 
                 items.append(term)

--- a/manala.ansible-galaxy/tasks/roles.yml
+++ b/manala.ansible-galaxy/tasks/roles.yml
@@ -23,6 +23,12 @@
     {{ manala_ansible_galaxy_bin|ternary(manala_ansible_galaxy_bin, 'ansible-galaxy') }} install
     --role-file=/tmp/manala_ansible_galaxy_roles.yml
     --roles-path={{ manala_ansible_galaxy_roles_path|ternary(manala_ansible_galaxy_roles_path, '/etc/ansible/roles') }}
+    {{ (
+      (ansible_distribution_release == 'wheezy')
+      and
+      (manala_ansible_galaxy_bin|ternary(manala_ansible_galaxy_bin, 'ansible-galaxy') == 'ansible-galaxy')
+      )|ternary('--ignore-certs', '')
+    }}
     {{ manala_ansible_galaxy_force|ternary('--force', '') }}
   when: manala_ansible_galaxy_roles|length
 

--- a/manala.ansible-galaxy/tests/0200_roles.goss.yml
+++ b/manala.ansible-galaxy/tests/0200_roles.goss.yml
@@ -3,7 +3,7 @@
 file:
   /tmp/manala_ansible_galaxy_roles.yml:
     exists: false
-  /etc/ansible/roles/carlosbuenosvinos.ansistrano-deploy:
+  /etc/ansible/roles/ansistrano.deploy:
     exists:   true
     filetype: directory
   /etc/ansible/roles/jdauphant.nginx:

--- a/manala.ansible-galaxy/tests/0200_roles.yml
+++ b/manala.ansible-galaxy/tests/0200_roles.yml
@@ -5,7 +5,7 @@
   become: true
   vars:
     manala_ansible_galaxy_roles:
-      - carlosbuenosvinos.ansistrano-deploy
+      - ansistrano.deploy
       - jdauphant.nginx
       - src: jdauphant.nginx
         version: v1.11.4

--- a/manala.ansible/CHANGELOG.md
+++ b/manala.ansible/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-06-05
 ### Added

--- a/manala.ansible/lookup_plugins/manala_ansible_files.py
+++ b/manala.ansible/lookup_plugins/manala_ansible_files.py
@@ -40,7 +40,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Expect a dict')
 
             # Check index key
-            if not file.has_key('file'):
+            if 'file' not in file:
                 raise AnsibleError('Expect "file" key')
 
             item = itemDefault.copy()

--- a/manala.ansible/templates/config/_base.j2
+++ b/manala.ansible/templates/config/_base.j2
@@ -14,7 +14,7 @@
 {% set config_diff = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'defaults' -%}
             {%- if config_defaults.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'inventory' -%}
@@ -538,8 +538,8 @@
 # only be disabled if your sftp version has problems with batch mode
 {{ macros.config_row(config_ssh_connection, 'sftp_batch_mode', '#sftp_batch_mode = False', 0, true) }}
 
-# The -tt argument is passed to ssh when pipelining is not enabled because sudo 
-# requires a tty by default. 
+# The -tt argument is passed to ssh when pipelining is not enabled because sudo
+# requires a tty by default.
 {{ macros.config_row(config_ssh_connection, 'use_tty', '#use_tty = True', 0, true) }}
 
 {{ macros.config(config_ssh_connection, [

--- a/manala.ansible/templates/config/_macros.j2
+++ b/manala.ansible/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.ansible/templates/group_vars/_macros.j2
+++ b/manala.ansible/templates/group_vars/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.ansible/templates/host_vars/_macros.j2
+++ b/manala.ansible/templates/host_vars/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.ansible/templates/hosts/_macros.j2
+++ b/manala.ansible/templates/hosts/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.apt/CHANGELOG.md
+++ b/manala.apt/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.23] - 2018-08-21
 ### Fixed

--- a/manala.apt/lookup_plugins/manala_apt_keys.py
+++ b/manala.apt/lookup_plugins/manala_apt_keys.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -17,7 +18,7 @@ class LookupModule(LookupBase):
         repositoryPosition = 0
         for repository in repositories:
 
-            if repository.has_key('key'):
+            if 'key' in repository:
                 terms[0].insert(repositoryPosition, repository.get('key'))
                 repositoryPosition += 1
 
@@ -26,7 +27,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 items.append(
                     keys_patterns.get(term)
                 )
@@ -36,7 +37,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('id'):
+                if 'id' not in term:
                     raise AnsibleError('Expect "id" key')
 
                 items.append(term)

--- a/manala.apt/lookup_plugins/manala_apt_packages.py
+++ b/manala.apt/lookup_plugins/manala_apt_packages.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -24,7 +25,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 item = itemDefault.copy()
                 item.update({
                     'package': term
@@ -36,7 +37,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('package'):
+                if 'package' not in term:
                     raise AnsibleError('Expect "package" key')
 
                 item = itemDefault.copy()

--- a/manala.apt/lookup_plugins/manala_apt_preferences.py
+++ b/manala.apt/lookup_plugins/manala_apt_preferences.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 import re
@@ -20,7 +21,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 items.append({
                     'file': term
                         .split('@')[0]
@@ -66,7 +67,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('file'):
+                if 'file' not in term:
                     raise AnsibleError('Expect "file" key')
 
                 items.append(term)

--- a/manala.apt/lookup_plugins/manala_apt_repositories.py
+++ b/manala.apt/lookup_plugins/manala_apt_repositories.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -17,7 +18,7 @@ class LookupModule(LookupBase):
         preferencePosition = 0
         for preference in preferences:
 
-            if isinstance(preference, basestring):
+            if isinstance(preference, string_types):
                 term = ((preference.split('@')[1])
                     if len(preference.split('@')) > 1 else
                 (preference)).split(':')[0]
@@ -29,7 +30,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 items.append(
                     repositories_patterns.get(term)
                 )
@@ -39,13 +40,13 @@ class LookupModule(LookupBase):
                 if not isinstance(term, dict):
                     raise AnsibleError('Expect a dict')
 
-                if term.has_key('pattern'):
+                if 'pattern' in term:
                     item = repositories_patterns.get(term.get('pattern'))
                     item.update(term)
                     items.append(item)
                 else:
                     # Check index key
-                    if not term.has_key('source'):
+                    if 'source' not in term:
                         raise AnsibleError('Expect "source" key')
 
                     items.append(term)

--- a/manala.apt/templates/sources_list/_macros.j2
+++ b/manala.apt/templates/sources_list/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}

--- a/manala.aptly/CHANGELOG.md
+++ b/manala.aptly/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.aptly/templates/config/_macros.j2
+++ b/manala.aptly/templates/config/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{% if not outer_loop.last %},{% endif %}{{ '\n' }}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.backup-manager/CHANGELOG.md
+++ b/manala.backup-manager/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.backup-manager/templates/configs/_macros.j2
+++ b/manala.backup-manager/templates/configs/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.beanstalkd/CHANGELOG.md
+++ b/manala.beanstalkd/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.beanstalkd/templates/config/_macros.j2
+++ b/manala.beanstalkd/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.cloud-init/CHANGELOG.md
+++ b/manala.cloud-init/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.cloud-init/templates/configs/_macros.j2
+++ b/manala.cloud-init/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.composer/CHANGELOG.md
+++ b/manala.composer/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.composer/templates/users/auth/_macros.j2
+++ b/manala.composer/templates/users/auth/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.cron/CHANGELOG.md
+++ b/manala.cron/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-10-12
 ### Added

--- a/manala.cron/lookup_plugins/manala_cron_files_env.py
+++ b/manala.cron/lookup_plugins/manala_cron_files_env.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types, iteritems
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -14,16 +15,16 @@ class LookupModule(LookupBase):
 
         for file in files:
 
-            if file.has_key('env'):
+            if 'env' in file:
                 env = file.get('env')
 
                 # Env must be a dict
                 if not isinstance(env, dict):
                     raise AnsibleError('Expected a dict')
 
-                for name,value in env.iteritems():
+                for name,value in iteritems(env):
 
-                    if not isinstance(value, (basestring, int, float)) or isinstance(value, bool):
+                    if not isinstance(value, (string_types, int, float)) or isinstance(value, bool):
                         raise AnsibleError("Expected a string, an integer or a float for key \"%s\" in manala_cron_files env" % name)
 
                     item = {
@@ -32,7 +33,7 @@ class LookupModule(LookupBase):
                         'value': value
                     }
 
-                    if file.has_key('user'):
+                    if 'user' in file:
                         item['user'] = file.get('user')
 
                     results.append(item)

--- a/manala.cron/tasks/files.yml
+++ b/manala.cron/tasks/files.yml
@@ -19,11 +19,12 @@
     - cron restart
 
 - name: files > Env variables
-  cronvar:
+  cron:
     cron_file: "{{ item.file }}"
+    env:       true
     name:      "{{ item.name }}"
     value:     "{{ item.value }}"
-    user:      "{{ item.user|default(omit) }}"
+    user:      "{{ item.user|default('root') }}"
     state:     present
   with_manala_cron_files_env:
     - "{{ manala_cron_files }}"
@@ -32,11 +33,12 @@
 
 # Deprecated
 - name: files > Environment variables (deprecated)
-  cronvar:
+  cron:
     cron_file: "{{ item.0.file }}"
-    name:      "{{ item.1.keys()[0] }}"
-    value:     "{{ item.1.values()[0] }}"
-    user:      "{{ item.0.user|default(omit) }}"
+    env:       true
+    name:      "{{ (item.1.keys()|list)[0] }}"
+    value:     "{{ (item.1.values()|list)[0] }}"
+    user:      "{{ item.0.user|default('root') }}"
     state:     present
   with_subelements:
     - "{{ manala_cron_files }}"

--- a/manala.cron/tests/0200_files.goss.yml
+++ b/manala.cron/tests/0200_files.goss.yml
@@ -8,8 +8,8 @@ file:
     group: root
     filetype: file
     contains:
-      - 'FOO=foo'
-      - 'BAR=bar'
+      - 'FOO="foo"'
+      - 'BAR="bar"'
       - '#Ansible: foo-foo'
       - '0 7 * * * foo cd /srv/app && bin/console app:foo:foo'
   /etc/cron.d/bar:
@@ -28,7 +28,7 @@ file:
     group: root
     filetype: file
     contains:
-      - 'BAR=bar'
-      - 'QUX=qux'
+      - 'BAR="bar"'
+      - 'QUX="qux"'
       - '#Ansible: baz-baz'
       - '0 7 * * * root cd /srv/app && bin/console app:baz:baz'

--- a/manala.deploy/CHANGELOG.md
+++ b/manala.deploy/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.6] - 2018-06-05
 ### Added

--- a/manala.deploy/lookup_plugins/manala_deploy_tasks.py
+++ b/manala.deploy/lookup_plugins/manala_deploy_tasks.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -15,11 +16,11 @@ class LookupModule(LookupBase):
             'when':    True,
             'dir':
                 (variables['deploy_helper']['new_release_path'])
-                    if variables.has_key('deploy_helper') else
+                    if 'deploy_helper' in variables else
                 (variables['manala_deploy_dir'] + '/' +  variables['manala_deploy_current_dir']),
             'shared_dir':
                 (variables['deploy_helper']['shared_path'])
-                    if variables.has_key('deploy_helper') else
+                    if 'deploy_helper' in variables else
                 (variables['manala_deploy_dir'] + '/' +  variables['manala_deploy_shared_dir'])
         }
 
@@ -28,7 +29,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Task as a single line
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 item = itemDefault.copy()
                 item.update({
                     'task': term
@@ -47,7 +48,7 @@ class LookupModule(LookupBase):
                         break
                 if item:
                     item.update({
-                        'when': term.get('when') if term.has_key('when') else True
+                        'when': term.get('when') if 'when' in term else True
                     })
                     items.append(item)
 

--- a/manala.deploy/lookup_plugins/manala_deploy_writable_dirs.py
+++ b/manala.deploy/lookup_plugins/manala_deploy_writable_dirs.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -18,7 +19,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Dir as a single line
-            if isinstance(dir, basestring):
+            if isinstance(dir, string_types):
                 item = default.copy()
                 item.update({
                     'dir': dir
@@ -31,7 +32,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not dir.has_key('dir'):
+                if 'dir' not in dir:
                     raise AnsibleError('Expect "dir" key')
 
                 item = default.copy()

--- a/manala.dnsmasq/CHANGELOG.md
+++ b/manala.dnsmasq/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.dnsmasq/templates/configs/_macros.j2
+++ b/manala.dnsmasq/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.docker/CHANGELOG.md
+++ b/manala.docker/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.12] - 2018-06-29
 ### Added

--- a/manala.docker/lookup_plugins/manala_docker_applications.py
+++ b/manala.docker/lookup_plugins/manala_docker_applications.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -29,7 +30,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 item = itemDefault.copy()
 
                 item.update({
@@ -40,7 +41,7 @@ class LookupModule(LookupBase):
                 })
 
                 # Pattern
-                if patterns.has_key(term.split(':')[0]):
+                if term.split(':')[0] in patterns:
                     item.update(patterns.get(term.split(':')[0]))
 
                 # Tag
@@ -55,10 +56,10 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('application'):
+                if 'application' not in term:
                     raise AnsibleError('Expect "application" key')
 
-                if not term.has_key('image'):
+                if 'image' not in term:
                     raise AnsibleError('Expect "image" key')
 
                 item = itemDefault.copy()

--- a/manala.docker/templates/applications/default.j2
+++ b/manala.docker/templates/applications/default.j2
@@ -17,12 +17,12 @@ docker run
 {%- if item.interactive %}${INTERACTIVE}{% endif -%}
 {%- if item.tty %} --tty{% endif -%}
 {%- if item.volumes %}
-  {%- for source, destination in item.volumes.iteritems() -%}
+  {%- for source, destination in item.volumes.items() -%}
       {{ ' ' }}--volume {{ source }}:{{ destination }}
   {%- endfor -%}
 {% endif -%}
 {%- if item.environment %}
-  {%- for source, destination in item.environment.iteritems() -%}
+  {%- for source, destination in item.environment.items() -%}
       {{ ' ' }}--env {{ source }}={{ destination }}
   {%- endfor -%}
 {% endif -%}

--- a/manala.docker/templates/config_daemon/_macros.j2
+++ b/manala.docker/templates/config_daemon/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{% if not outer_loop.last %},{{ '\n' }}{% endif %}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.elasticsearch/CHANGELOG.md
+++ b/manala.elasticsearch/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-06-26
 ### Removed

--- a/manala.elasticsearch/templates/config/_macros.j2
+++ b/manala.elasticsearch/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.environment/CHANGELOG.md
+++ b/manala.environment/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-06-05
 ### Changed

--- a/manala.environment/lookup_plugins/manala_environment_files.py
+++ b/manala.environment/lookup_plugins/manala_environment_files.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -17,9 +18,9 @@ class LookupModule(LookupBase):
 
             items = []
 
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 # Pattern
-                if not patterns.has_key(term):
+                if term not in patterns:
                     raise AnsibleError('"%s" is not a valid pattern' % (term))
                 items.append({
                     'file':   patterns.get(term).get('file'),

--- a/manala.environment/lookup_plugins/manala_environment_variables.py
+++ b/manala.environment/lookup_plugins/manala_environment_variables.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -23,7 +24,7 @@ class LookupModule(LookupBase):
         if isinstance(terms[0], dict):
             for name in sorted(terms[0]):
                 value = terms[0].get(name)
-                if not isinstance(value, (basestring, int, float)) or isinstance(value, bool):
+                if not isinstance(value, (string_types, int, float)) or isinstance(value, bool):
                     raise AnsibleError("Expected a string, an integer or a float for key \"%s\" in manala_environment_variables" % name)
                 results.append({
                     'name':  name,
@@ -39,7 +40,7 @@ class LookupModule(LookupBase):
 
                 items = []
 
-                if term.has_key('name') and term.has_key('value'):
+                if 'name' in term and 'value' in term:
                     # Expanded syntax
                     items.append({
                         'name':  term.get('name'),
@@ -48,8 +49,8 @@ class LookupModule(LookupBase):
                 else:
                     # Short syntax
                     items.append({
-                        'name':  term.keys()[0],
-                        'value': self.legacy_format_value(term.values()[0])
+                        'name':  list(term.keys())[0],
+                        'value': self.legacy_format_value(list(term.values())[0])
                     })
 
                 # Merge by index key

--- a/manala.fail2ban/CHANGELOG.md
+++ b/manala.fail2ban/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.fail2ban/templates/config/_macros.j2
+++ b/manala.fail2ban/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.files/CHANGELOG.md
+++ b/manala.files/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-07-02
 ### Added

--- a/manala.files/lookup_plugins/manala_files_attributes.py
+++ b/manala.files/lookup_plugins/manala_files_attributes.py
@@ -25,14 +25,14 @@ class LookupModule(LookupBase):
         for attribute in attributes:
 
             # Check index key
-            if not attribute.has_key('path'):
+            if 'path' not in attribute:
                 raise AnsibleError('Expect "path" key')
 
             items = []
 
             # State - Link Directory
-            if attribute.has_key('state') and (attribute['state'] == 'link_directory'):
-                if not attribute.has_key('src'):
+            if  'state' in attribute and (attribute['state'] == 'link_directory'):
+                if 'src' not in attribute:
                     raise AnsibleError('Expect "src" key')
                 # Directory (src)
                 item = self._default(defaults, attribute['src'])
@@ -54,7 +54,7 @@ class LookupModule(LookupBase):
                 })
                 items.append(item)
             # State - Link File
-            elif attribute.has_key('state') and (attribute['state'] == 'link_file'):
+            elif 'state' in attribute and (attribute['state'] == 'link_file'):
                 item = self._default(defaults, attribute['path'])
                 item.update(attribute)
                 item.update({
@@ -63,7 +63,7 @@ class LookupModule(LookupBase):
                 items.append(item)
             else:
                 # Template
-                if attribute.has_key('template'):
+                if 'template' in attribute:
                     item = self._default(defaults, attribute['path'])
                     item.update(attribute)
                     item.update({
@@ -71,7 +71,7 @@ class LookupModule(LookupBase):
                     })
                     items.append(item)
                 # Content
-                elif attribute.has_key('content'):
+                elif 'content' in attribute:
                     item = self._default(defaults, attribute['path'])
                     item.update(attribute)
                     item.update({
@@ -79,7 +79,7 @@ class LookupModule(LookupBase):
                     })
                     items.append(item)
                 # Copy
-                elif attribute.has_key('copy'):
+                elif 'copy' in attribute:
                     item = self._default(defaults, attribute['path'])
                     item.update(attribute)
                     item.update({
@@ -87,7 +87,7 @@ class LookupModule(LookupBase):
                     })
                     items.append(item)
                 # Url
-                elif attribute.has_key('url'):
+                elif 'url' in attribute:
                     item = self._default(defaults, attribute['path'])
                     item.update(attribute)
                     item.update({

--- a/manala.git/CHANGELOG.md
+++ b/manala.git/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Added

--- a/manala.git/templates/config/_macros.j2
+++ b/manala.git/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.git/templates/config/default.dev.j2
+++ b/manala.git/templates/config/default.dev.j2
@@ -6,7 +6,7 @@
 {% set config_oh_my_zsh = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'core' -%}
             {%- if config_core.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'oh-my-zsh' -%}

--- a/manala.git/templates/config/default.prod.j2
+++ b/manala.git/templates/config/default.prod.j2
@@ -5,7 +5,7 @@
 {% set config_core = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'core' -%}
             {%- if config_core.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.git/templates/config/default.test.j2
+++ b/manala.git/templates/config/default.test.j2
@@ -6,7 +6,7 @@
 {% set config_oh_my_zsh = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'core' -%}
             {%- if config_core.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'oh-my-zsh' -%}

--- a/manala.grafana/CHANGELOG.md
+++ b/manala.grafana/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.grafana/templates/config/2.0/default.j2
+++ b/manala.grafana/templates/config/2.0/default.j2
@@ -18,7 +18,7 @@
 {% set config_event_publisher = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'paths' -%}
             {%- if config_paths.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'server' -%}

--- a/manala.grafana/templates/config/2.1/default.j2
+++ b/manala.grafana/templates/config/2.1/default.j2
@@ -24,7 +24,7 @@
 {% set config_dashboards_json = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'paths' -%}
             {%- if config_paths.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'server' -%}

--- a/manala.grafana/templates/config/2.5/default.j2
+++ b/manala.grafana/templates/config/2.5/default.j2
@@ -24,7 +24,7 @@
 {% set config_dashboards_json = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'paths' -%}
             {%- if config_paths.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'server' -%}

--- a/manala.grafana/templates/config/3.1/default.j2
+++ b/manala.grafana/templates/config/3.1/default.j2
@@ -27,7 +27,7 @@
 {% set config_grafana_net = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'paths' -%}
             {%- if config_paths.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'server' -%}

--- a/manala.grafana/templates/config/4.0/default.j2
+++ b/manala.grafana/templates/config/4.0/default.j2
@@ -35,7 +35,7 @@
 {% set config_external_image_storage_webdav = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'paths' -%}
             {%- if config_paths.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'server' -%}

--- a/manala.grafana/templates/config/4.1/default.j2
+++ b/manala.grafana/templates/config/4.1/default.j2
@@ -35,7 +35,7 @@
 {% set config_external_image_storage_webdav = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'paths' -%}
             {%- if config_paths.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'server' -%}

--- a/manala.grafana/templates/config/_macros.j2
+++ b/manala.grafana/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.influxdb/CHANGELOG.md
+++ b/manala.influxdb/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-08-14
 ### Changed

--- a/manala.influxdb/templates/config/_macros.j2
+++ b/manala.influxdb/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.influxdb/templates/config/base.conf.j2
+++ b/manala.influxdb/templates/config/base.conf.j2
@@ -22,7 +22,7 @@
 {% set config_tls = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'meta' -%}
             {%- if config_meta.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'data' -%}

--- a/manala.keepalived/CHANGELOG.md
+++ b/manala.keepalived/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.keepalived/templates/config/_macros.j2
+++ b/manala.keepalived/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter|indent(indent, true) }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.keepalived/templates/environment/_macros.j2
+++ b/manala.keepalived/templates/environment/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter|indent(indent, true) }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.locales/CHANGELOG.md
+++ b/manala.locales/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Changed

--- a/manala.locales/lookup_plugins/manala_locales_codes.py
+++ b/manala.locales/lookup_plugins/manala_locales_codes.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 # As seen on native locale_gen module
@@ -54,7 +55,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(code, basestring):
+            if isinstance(code, string_types):
                 item = itemDefault.copy()
                 item.update({
                     'code': code
@@ -66,7 +67,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not code.has_key('code'):
+                if 'code' not in code:
                     raise AnsibleError('Expect "code" key')
 
                 item = itemDefault.copy()

--- a/manala.logentries/CHANGELOG.md
+++ b/manala.logentries/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.1] - 2018-06-05
 ### Added

--- a/manala.logentries/templates/config/_macros.j2
+++ b/manala.logentries/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.logrotate/CHANGELOG.md
+++ b/manala.logrotate/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.logrotate/templates/configs/_macros.j2
+++ b/manala.logrotate/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter|indent(indent, true) }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.mailhog/CHANGELOG.md
+++ b/manala.mailhog/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.mailhog/templates/config/_macros.j2
+++ b/manala.mailhog/templates/config/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{% if not outer_loop.last %} {% endif %}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.maxscale/CHANGELOG.md
+++ b/manala.maxscale/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.maxscale/lookup_plugins/manala_maxscale_configs.py
+++ b/manala.maxscale/lookup_plugins/manala_maxscale_configs.py
@@ -40,7 +40,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Expect a dict')
 
             # Check index key
-            if not config.has_key('file'):
+            if 'file' not in config:
                 raise AnsibleError('Expect "file" key')
 
             item = itemDefault.copy()

--- a/manala.maxscale/templates/config/_macros.j2
+++ b/manala.maxscale/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.maxscale/templates/configs/_macros.j2
+++ b/manala.maxscale/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.maxscale/tests/0102_install.2.2.yml
+++ b/manala.maxscale/tests/0102_install.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
     - import_tasks: pre_tasks/disable_systemd.yml

--- a/manala.maxscale/tests/0202_config.2.2.yml
+++ b/manala.maxscale/tests/0202_config.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_maxscale_config:

--- a/manala.maxscale/tests/0302_configs.2.2.yml
+++ b/manala.maxscale/tests/0302_configs.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}.1"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_maxscale_configs_dir: "{{ manala_maxscale_config_file }}.d.test"
@@ -28,7 +28,7 @@
       command: goss --gossfile {{ test }}.goss.1.yml validate
 
 - name: "{{ test }}.2"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_maxscale_configs_dir: "{{ manala_maxscale_config_file }}.d.test"

--- a/manala.maxscale/tests/0312_configs_exclusive.2.2.yml
+++ b/manala.maxscale/tests/0312_configs_exclusive.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}.1"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_maxscale_configs_dir: "{{ manala_maxscale_config_file }}.d.test"
@@ -17,7 +17,7 @@
     - manala.maxscale
 
 - name: "{{ test }}.2"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_maxscale_configs_dir: "{{ manala_maxscale_config_file }}.d.test"

--- a/manala.maxscale/tests/0402_users_untouched.2.2.yml
+++ b/manala.maxscale/tests/0402_users_untouched.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
     - import_tasks: pre_tasks/disable_systemd.yml

--- a/manala.maxscale/tests/0412_users_empty.2.2.yml
+++ b/manala.maxscale/tests/0412_users_empty.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_maxscale_network_users: []

--- a/manala.maxscale/tests/0422_users.2.2.yml
+++ b/manala.maxscale/tests/0422_users.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   vars:
     manala_maxscale_network_users:

--- a/manala.maxscale/tests/0502_services.2.2.yml
+++ b/manala.maxscale/tests/0502_services.2.2.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "{{ test }}"
-  hosts: debian
+  hosts: debian:!debian.wheezy
   become: true
   pre_tasks:
     - import_tasks: pre_tasks/disable_systemd.yml

--- a/manala.merge/CHANGELOG.md
+++ b/manala.merge/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Changed

--- a/manala.merge/library/manala_set.py
+++ b/manala.merge/library/manala_set.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from ansible.module_utils.six import iteritems
+
 def main():
 
     module = AnsibleModule(
@@ -16,7 +18,7 @@ def main():
 
     facts = dict()
 
-    for key, value in hash.iteritems():
+    for key, value in iteritems(hash):
         if prefix:
             facts[prefix + key] = hash[key]
         else:

--- a/manala.mongodb/CHANGELOG.md
+++ b/manala.mongodb/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Added

--- a/manala.mongodb/templates/config/_macros.j2
+++ b/manala.mongodb/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.mysql/CHANGELOG.md
+++ b/manala.mysql/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-06-05
 ### Added

--- a/manala.mysql/templates/configs/_macros.j2
+++ b/manala.mysql/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.mysql/templates/configs/default.dev.j2
+++ b/manala.mysql/templates/configs/default.dev.j2
@@ -5,7 +5,7 @@
 {% set config_mysqld = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'mysqld' -%}
             {%- if config_mysqld.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.network/CHANGELOG.md
+++ b/manala.network/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-08-22
 ### Changed

--- a/manala.network/tasks/hosts.yml
+++ b/manala.network/tasks/hosts.yml
@@ -3,7 +3,7 @@
 - name: hosts > File
   lineinfile:
     path:   "{{ manala_network_hosts_file }}"
-    regexp: "^{{ item.keys()[0]|regex_escape() }}\\s+"
-    line:   "{{ item.keys()[0] }} {{ item.values()[0] }}"
+    regexp: "^{{ (item.keys()|list)[0]|regex_escape() }}\\s+"
+    line:   "{{ (item.keys()|list)[0] }} {{ (item.values()|list)[0] }}"
     unsafe_writes: true
   with_items: "{{ manala_network_hosts }}"

--- a/manala.network/tasks/routing_tables.yml
+++ b/manala.network/tasks/routing_tables.yml
@@ -3,6 +3,6 @@
 - name: routing_tables > File
   lineinfile:
     path:   "{{ manala_network_routing_tables_file }}"
-    regexp: "^{{ item.keys()[0] }}\\s+"
-    line:   "{{ item.keys()[0] }}	{{ item.values()[0] }}"
+    regexp: "^{{ (item.keys()|list)[0] }}\\s+"
+    line:   "{{ (item.keys()|list)[0] }}	{{ (item.values()|list)[0] }}"
   with_items: "{{ manala_network_routing_tables }}"

--- a/manala.network/templates/interfaces/_macros.j2
+++ b/manala.network/templates/interfaces/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.network/templates/resolver/empty.conf.j2
+++ b/manala.network/templates/resolver/empty.conf.j2
@@ -1,3 +1,3 @@
 {%- for config in manala_network_resolver_config %}
-{{ config.keys()[0] }} {{ config.values()[0] }}
+{{ (config.keys()|list)[0] }} {{ (config.values()|list)[0] }}
 {% endfor -%}

--- a/manala.nginx/CHANGELOG.md
+++ b/manala.nginx/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-10-12
 ### Added

--- a/manala.nginx/templates/config/_macros.j2
+++ b/manala.nginx/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.nginx/templates/config/default.j2
+++ b/manala.nginx/templates/config/default.j2
@@ -6,7 +6,7 @@
 {% set config_http = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'events' -%}
             {%- if config_events.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'http' -%}

--- a/manala.nginx/templates/config/http.dev.j2
+++ b/manala.nginx/templates/config/http.dev.j2
@@ -6,7 +6,7 @@
 {% set config_http = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'events' -%}
             {%- if config_events.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'http' -%}

--- a/manala.nginx/templates/config/http.prod.j2
+++ b/manala.nginx/templates/config/http.prod.j2
@@ -6,7 +6,7 @@
 {% set config_http = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'events' -%}
             {%- if config_events.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'http' -%}

--- a/manala.nginx/templates/config/http.test.j2
+++ b/manala.nginx/templates/config/http.test.j2
@@ -6,7 +6,7 @@
 {% set config_http = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'events' -%}
             {%- if config_events.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'http' -%}

--- a/manala.nginx/templates/configs/_macros.j2
+++ b/manala.nginx/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter|indent(indent, true) }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.ngrok/CHANGELOG.md
+++ b/manala.ngrok/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.ngrok/templates/configs/_macros.j2
+++ b/manala.ngrok/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.npm/CHANGELOG.md
+++ b/manala.npm/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Changed

--- a/manala.npm/lookup_plugins/manala_npm_packages.py
+++ b/manala.npm/lookup_plugins/manala_npm_packages.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -13,13 +14,13 @@ class LookupModule(LookupBase):
         for term in self._flatten(terms):
 
             # Normalize term as dict
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 term = {
                     'package': term
                 }
 
             # Check index key
-            if not term.has_key('package'):
+            if 'package' not in term:
                 raise AnsibleError('Expect "package" key')
 
             # Merge by index key

--- a/manala.oauth2-proxy/CHANGELOG.md
+++ b/manala.oauth2-proxy/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.oauth2-proxy/templates/config/_macros.j2
+++ b/manala.oauth2-proxy/templates/config/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.ohmyzsh/CHANGELOG.md
+++ b/manala.ohmyzsh/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.6] - 2018-06-05
 ### Changed

--- a/manala.ohmyzsh/templates/users/_macros.j2
+++ b/manala.ohmyzsh/templates/users/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.phantomjs/CHANGELOG.md
+++ b/manala.phantomjs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.phantomjs/templates/config/_macros.j2
+++ b/manala.phantomjs/templates/config/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{% if not outer_loop.last %},{{ '\n' }}{% endif %}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.php/CHANGELOG.md
+++ b/manala.php/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.10] - 2018-09-12
 ### Fixed

--- a/manala.php/lookup_plugins/manala_php_applications.py
+++ b/manala.php/lookup_plugins/manala_php_applications.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -24,11 +25,11 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 item = itemDefault.copy()
 
                 # Pattern
-                if not patterns.has_key(term.split('@')[0]):
+                if term.split('@')[0] not in patterns:
                     print(term.split('@')[0])
                     raise AnsibleError('Unknown pattern')
 
@@ -48,13 +49,13 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('application'):
+                if 'application' not in term:
                     raise AnsibleError('Expect "application" key')
 
                 item = itemDefault.copy()
 
                 # Pattern
-                if patterns.has_key(term.get('application')):
+                if term.get('application') in patterns:
                     item.update(patterns.get(term.get('application')))
 
                 item.update(term)

--- a/manala.php/lookup_plugins/manala_php_configs.py
+++ b/manala.php/lookup_plugins/manala_php_configs.py
@@ -19,7 +19,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Expect a dict')
 
             # Check index key
-            if not term.has_key('file'):
+            if 'file' not in term:
                 raise AnsibleError('Expect "file" key')
 
             items.append(term)

--- a/manala.php/lookup_plugins/manala_php_extensions.py
+++ b/manala.php/lookup_plugins/manala_php_extensions.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -31,7 +32,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 item = itemDefault.copy()
                 item.update({
                     'extension': term
@@ -43,7 +44,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('extension'):
+                if 'extension' not in term:
                     raise AnsibleError('Expect "extension" key')
 
                 item = itemDefault.copy()

--- a/manala.php/lookup_plugins/manala_php_fpm_pools.py
+++ b/manala.php/lookup_plugins/manala_php_fpm_pools.py
@@ -19,7 +19,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Expect a dict')
 
             # Check index key
-            if not term.has_key('file'):
+            if 'file' not in term:
                 raise AnsibleError('Expect "file" key')
 
             items.append(term)

--- a/manala.php/lookup_plugins/manala_php_fpm_pools_config.py
+++ b/manala.php/lookup_plugins/manala_php_fpm_pools_config.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types, iteritems
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -15,7 +16,7 @@ class LookupModule(LookupBase):
                 envValue = value.get(envKey)
                 # Empty values generate errors
                 # See: https://github.com/php/php-src/blob/PHP-7.2.9/sapi/fpm/fpm/fpm_conf.c#L1447
-                if not isinstance(envValue, (basestring, int, float)) or isinstance(envValue, bool) or envValue == "":
+                if not isinstance(envValue, (string_types, int, float)) or isinstance(envValue, bool) or envValue == "":
                     raise AnsibleError("Expected a non-empty string, an integer or a float for key \"%s\" in manala_php_fpm_pools config env" % envKey)
                 result += "env[%s] = \"%s\"\n" % (envKey, envValue)
 
@@ -30,7 +31,7 @@ class LookupModule(LookupBase):
         config = self._flatten(terms[0])
 
         for row in config:
-            for key, value in row.iteritems():
+            for key, value in iteritems(row):
                 if key == wantrow:
                     return self.format_row(key, value, wantrowtype)
 

--- a/manala.php/lookup_plugins/manala_php_sapis.py
+++ b/manala.php/lookup_plugins/manala_php_sapis.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -29,7 +30,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 item = itemDefault.copy()
                 item.update({
                     'sapi': term
@@ -41,7 +42,7 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('sapi'):
+                if 'sapi' not in term:
                     raise AnsibleError('Expect "sapi" key')
 
                 item = itemDefault.copy()

--- a/manala.php/tasks/requirements.yml
+++ b/manala.php/tasks/requirements.yml
@@ -2,8 +2,8 @@
 
 - name: requirements > Version
   fail:
-     msg: You must set "manala_php_version" to either {{ manala_php_versions.keys()|join(', ') }}
-  when: manala_php_version|string not in manala_php_versions.keys()
+     msg: You must set "manala_php_version" to either {{ manala_php_versions.keys()|list|join(', ') }}
+  when: manala_php_version|string not in manala_php_versions.keys()|list
   check_mode: false
 
 - name: requirements > Version release

--- a/manala.php/templates/blackfire/agent/_macros.j2
+++ b/manala.php/templates/blackfire/agent/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.php/templates/blackfire/client/_macros.j2
+++ b/manala.php/templates/blackfire/client/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.php/templates/configs/_macros.j2
+++ b/manala.php/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.php/templates/fpm_pools/5.6/_base.j2
+++ b/manala.php/templates/fpm_pools/5.6/_base.j2
@@ -1,6 +1,6 @@
 {%- for configs in item.config|default([config_name_default]) -%}
 
-    {%- for config_name, config in ({configs: []} if (configs is string) else configs).iteritems() -%}
+    {%- for config_name, config in ({configs: []} if (configs is string) else configs).items() -%}
 
 ; Start a new pool named '{{ config_name }}'.
 ; the variable $pool can we used in any directive and will be replaced by the
@@ -414,9 +414,9 @@
 {{ macros.config_row(config, 'php_admin_flag[log_errors]', ';php_admin_flag[log_errors] = on', true) }}
 {{ macros.config_row(config, 'php_admin_value[memory_limit]', ';php_admin_value[memory_limit] = 32M', true) }}
 
-{% for config_extra_key, config_extra_value in config_extra.iteritems() -%}
+{% for config_extra_key, config_extra_value in config_extra.items() -%}
 {{ macros.config_row(config, config_extra_key, config_extra_value) }}
-{%- endfor %}
+{% endfor %}
 
 {{ macros.config(config, [
   'prefix',
@@ -459,7 +459,7 @@
   'php_admin_value[error_log]',
   'php_admin_flag[log_errors]',
   'php_admin_value[memory_limit]'
-] + config_extra.keys()) -}}
+] + config_extra.keys()|list) -}}
 
     {%- endfor %}
 

--- a/manala.php/templates/fpm_pools/5/_base.j2
+++ b/manala.php/templates/fpm_pools/5/_base.j2
@@ -1,6 +1,6 @@
 {%- for configs in item.config|default([config_name_default]) -%}
 
-    {%- for config_name, config in ({configs: []} if (configs is string) else configs).iteritems() -%}
+    {%- for config_name, config in ({configs: []} if (configs is string) else configs).items() -%}
 
 ; Start a new pool named '{{ config_name }}'.
 ; the variable $pool can we used in any directive and will be replaced by the
@@ -414,9 +414,9 @@
 {{ macros.config_row(config, 'php_admin_flag[log_errors]', ';php_admin_flag[log_errors] = on', true) }}
 {{ macros.config_row(config, 'php_admin_value[memory_limit]', ';php_admin_value[memory_limit] = 32M', true) }}
 
-{% for config_extra_key, config_extra_value in config_extra.iteritems() -%}
+{% for config_extra_key, config_extra_value in config_extra.items() -%}
 {{ macros.config_row(config, config_extra_key, config_extra_value) }}
-{%- endfor %}
+{% endfor %}
 
 {{ macros.config(config, [
   'prefix',
@@ -459,7 +459,7 @@
   'php_admin_value[error_log]',
   'php_admin_flag[log_errors]',
   'php_admin_value[memory_limit]'
-] + config_extra.keys()) -}}
+] + config_extra.keys()|list) -}}
 
     {%- endfor %}
 

--- a/manala.php/templates/fpm_pools/7.0/_base.j2
+++ b/manala.php/templates/fpm_pools/7.0/_base.j2
@@ -1,6 +1,6 @@
 {%- for configs in item.config|default([config_name_default]) -%}
 
-    {%- for config_name, config in ({configs: []} if (configs is string) else configs).iteritems() -%}
+    {%- for config_name, config in ({configs: []} if (configs is string) else configs).items() -%}
 
 ; Start a new pool named '{{ config_name }}'.
 ; the variable $pool can be used in any directive and will be replaced by the
@@ -416,9 +416,9 @@
 {{ macros.config_row(config, 'php_admin_flag[log_errors]', ';php_admin_flag[log_errors] = on', true) }}
 {{ macros.config_row(config, 'php_admin_value[memory_limit]', ';php_admin_value[memory_limit] = 32M', true) }}
 
-{% for config_extra_key, config_extra_value in config_extra.iteritems() -%}
+{% for config_extra_key, config_extra_value in config_extra.items() -%}
 {{ macros.config_row(config, config_extra_key, config_extra_value) }}
-{%- endfor %}
+{% endfor %}
 
 {{ macros.config(config, [
   'prefix',
@@ -461,7 +461,7 @@
   'php_admin_value[error_log]',
   'php_admin_flag[log_errors]',
   'php_admin_value[memory_limit]'
-] + config_extra.keys()) -}}
+] + config_extra.keys()|list) -}}
 
     {%- endfor %}
 

--- a/manala.php/templates/fpm_pools/7.1/_base.j2
+++ b/manala.php/templates/fpm_pools/7.1/_base.j2
@@ -1,6 +1,6 @@
 {%- for configs in item.config|default([config_name_default]) -%}
 
-    {%- for config_name, config in ({configs: []} if (configs is string) else configs).iteritems() -%}
+    {%- for config_name, config in ({configs: []} if (configs is string) else configs).items() -%}
 
 ; Start a new pool named '{{ config_name }}'.
 ; the variable $pool can be used in any directive and will be replaced by the
@@ -416,9 +416,9 @@
 {{ macros.config_row(config, 'php_admin_flag[log_errors]', ';php_admin_flag[log_errors] = on', true) }}
 {{ macros.config_row(config, 'php_admin_value[memory_limit]', ';php_admin_value[memory_limit] = 32M', true) }}
 
-{% for config_extra_key, config_extra_value in config_extra.iteritems() -%}
+{% for config_extra_key, config_extra_value in config_extra.items() -%}
 {{ macros.config_row(config, config_extra_key, config_extra_value) }}
-{%- endfor %}
+{% endfor %}
 
 {{ macros.config(config, [
   'prefix',
@@ -461,7 +461,7 @@
   'php_admin_value[error_log]',
   'php_admin_flag[log_errors]',
   'php_admin_value[memory_limit]'
-] + config_extra.keys()) -}}
+] + config_extra.keys()|list) -}}
 
     {%- endfor %}
 

--- a/manala.php/templates/fpm_pools/7.2/_base.j2
+++ b/manala.php/templates/fpm_pools/7.2/_base.j2
@@ -1,6 +1,6 @@
 {%- for configs in item.config|default([config_name_default]) -%}
 
-    {%- for config_name, config in ({configs: []} if (configs is string) else configs).iteritems() -%}
+    {%- for config_name, config in ({configs: []} if (configs is string) else configs).items() -%}
 
 ; Start a new pool named '{{ config_name }}'.
 ; the variable $pool can be used in any directive and will be replaced by the
@@ -420,9 +420,9 @@
 {{ macros.config_row(config, 'php_admin_flag[log_errors]', ';php_admin_flag[log_errors] = on', true) }}
 {{ macros.config_row(config, 'php_admin_value[memory_limit]', ';php_admin_value[memory_limit] = 32M', true) }}
 
-{% for config_extra_key, config_extra_value in config_extra.iteritems() -%}
+{% for config_extra_key, config_extra_value in config_extra.items() -%}
 {{ macros.config_row(config, config_extra_key, config_extra_value) }}
-{%- endfor %}
+{% endfor %}
 
 {{ macros.config(config, [
   'prefix',
@@ -466,7 +466,7 @@
   'php_admin_value[error_log]',
   'php_admin_flag[log_errors]',
   'php_admin_value[memory_limit]'
-] + config_extra.keys()) -}}
+] + config_extra.keys()|list) -}}
 
     {%- endfor %}
 

--- a/manala.php/templates/fpm_pools/_macros.j2
+++ b/manala.php/templates/fpm_pools/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.php/templates/fpm_pools/empty.j2
+++ b/manala.php/templates/fpm_pools/empty.j2
@@ -2,7 +2,7 @@
 
 {%- for configs in item.config|default(['www']) -%}
 
-    {%- for config_name, config in ({configs: []} if (configs is string) else configs).iteritems() -%}
+    {%- for config_name, config in ({configs: []} if (configs is string) else configs).items() -%}
 
 [{{ config_name }}]
 

--- a/manala.phpmyadmin/CHANGELOG.md
+++ b/manala.phpmyadmin/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Added

--- a/manala.phpmyadmin/templates/configs/_macros.j2
+++ b/manala.phpmyadmin/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, server_name) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.phppgadmin/CHANGELOG.md
+++ b/manala.phppgadmin/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Added

--- a/manala.phppgadmin/templates/configs/_macros.j2
+++ b/manala.phppgadmin/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, server_name) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.phpredisadmin/CHANGELOG.md
+++ b/manala.phpredisadmin/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-06-05
 ### Added

--- a/manala.phpredisadmin/templates/configs/_macros.j2
+++ b/manala.phpredisadmin/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.postgresql/CHANGELOG.md
+++ b/manala.postgresql/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Added

--- a/manala.postgresql/templates/config/_macros.j2
+++ b/manala.postgresql/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.postgresql/templates/config/hba/_macros.j2
+++ b/manala.postgresql/templates/config/hba/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.proftpd/CHANGELOG.md
+++ b/manala.proftpd/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.proftpd/templates/configs/_macros.j2
+++ b/manala.proftpd/templates/configs/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.proxmox/CHANGELOG.md
+++ b/manala.proxmox/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-06-28
 ### Added

--- a/manala.proxmox/lookup_plugins/manala_proxmox_files.py
+++ b/manala.proxmox/lookup_plugins/manala_proxmox_files.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 import os
@@ -36,7 +37,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(file, basestring):
+            if isinstance(file, string_types):
                 item = itemDefault.copy()
                 item.update({
                     'url': file
@@ -46,16 +47,16 @@ class LookupModule(LookupBase):
                 if not isinstance(file, dict):
                     raise AnsibleError('Expect a dict')
 
-                if (not file.has_key('file')) and (not file.has_key('url')):
+                if ('file' not in file) and ('url' not in file):
                     raise AnsibleError('Expect "url" or "file" key')
 
-                if (file.get('state') == 'present') and (not file.has_key('url')):
+                if (file.get('state') == 'present') and ('url' not in file):
                     raise AnsibleError('Expect "url" key for present state')
 
                 item = itemDefault.copy()
                 item.update(file)
 
-            if item.has_key('url') and not item.has_key('file'):
+            if 'url' in item and 'file' not in item:
                 item.update({
                     'file': os.path.basename(item['url'])
                 })

--- a/manala.redis/CHANGELOG.md
+++ b/manala.redis/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-07-19
 ### Added

--- a/manala.redis/templates/config/_macros.j2
+++ b/manala.redis/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.rsyslog/CHANGELOG.md
+++ b/manala.rsyslog/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.rsyslog/templates/config/_macros.j2
+++ b/manala.rsyslog/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.rsyslog/templates/configs/_macros.j2
+++ b/manala.rsyslog/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.rtail/CHANGELOG.md
+++ b/manala.rtail/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.rtail/templates/config/_macros.j2
+++ b/manala.rtail/templates/config/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{% if not outer_loop.last %} {% endif %}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.sensu/CHANGELOG.md
+++ b/manala.sensu/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-07-10
 ### Changed

--- a/manala.sensu/templates/config/empty.j2
+++ b/manala.sensu/templates/config/empty.j2
@@ -1,4 +1,4 @@
-{% for key, value in manala_sensu_config.iteritems() -%}
+{% for key, value in manala_sensu_config.items() -%}
 	{{ key }}=
     {%- if value is sameas true -%}
         true

--- a/manala.shorewall/CHANGELOG.md
+++ b/manala.shorewall/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.shorewall/tasks/config.yml
+++ b/manala.shorewall/tasks/config.yml
@@ -3,8 +3,8 @@
 - name: config > File
   lineinfile:
     dest:   "{{ manala_shorewall_config_file }}"
-    regexp: "^{{ item.keys()[0] }}="
-    line:   "{{ item.keys()[0] }}={{ item.values()[0] }}"
+    regexp: "^{{ (item.keys()|list)[0] }}="
+    line:   "{{ (item.keys()|list)[0] }}={{ (item.values()|list)[0] }}"
   with_items: "{{ manala_shorewall_config }}"
   notify:
     - shorewall restart

--- a/manala.shorewall/templates/configs/_macros.j2
+++ b/manala.shorewall/templates/configs/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.ssh/CHANGELOG.md
+++ b/manala.ssh/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-07-10
 ### Fixed

--- a/manala.ssh/lookup_plugins/manala_ssh_known_hosts.py
+++ b/manala.ssh/lookup_plugins/manala_ssh_known_hosts.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -17,7 +18,7 @@ class LookupModule(LookupBase):
             items = []
 
             # Short syntax
-            if isinstance(term, basestring):
+            if isinstance(term, string_types):
                 item = patterns.get(term)
             else:
 
@@ -26,13 +27,13 @@ class LookupModule(LookupBase):
                     raise AnsibleError('Expect a dict')
 
                 # Check index key
-                if not term.has_key('host'):
+                if 'host' not in term:
                     raise AnsibleError('Expect "host" key')
 
                 item = term.copy()
 
             # File
-            if item.has_key('file'):
+            if 'file' in item:
                 item.pop('key', None)
                 # Relative
                 if not item.get('file').startswith('/'):

--- a/manala.ssh/templates/config/_macros.j2
+++ b/manala.ssh/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.ssh/templates/config/debian_jessie.j2
+++ b/manala.ssh/templates/config/debian_jessie.j2
@@ -5,7 +5,7 @@
 {% set config_host_wildcard = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'Host *' -%}
             {%- if config_host_wildcard.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.ssh/templates/config/debian_stretch.j2
+++ b/manala.ssh/templates/config/debian_stretch.j2
@@ -5,7 +5,7 @@
 {% set config_host_wildcard = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'Host *' -%}
             {%- if config_host_wildcard.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.ssh/templates/config/debian_wheezy.j2
+++ b/manala.ssh/templates/config/debian_wheezy.j2
@@ -5,7 +5,7 @@
 {% set config_host_wildcard = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'Host *' -%}
             {%- if config_host_wildcard.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.ssh/templates/config/default.dev.j2
+++ b/manala.ssh/templates/config/default.dev.j2
@@ -5,7 +5,7 @@
 {% set config_host_wildcard = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'Host *' -%}
             {%- if config_host_wildcard.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.ssh/templates/config/default.prod.j2
+++ b/manala.ssh/templates/config/default.prod.j2
@@ -5,7 +5,7 @@
 {% set config_host_wildcard = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'Host *' -%}
             {%- if config_host_wildcard.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.ssh/templates/config/default.test.j2
+++ b/manala.ssh/templates/config/default.test.j2
@@ -5,7 +5,7 @@
 {% set config_host_wildcard = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'Host *' -%}
             {%- if config_host_wildcard.extend(config_parameters) -%}{%- endif -%}
         {%- endif -%}

--- a/manala.ssh/templates/config/sshd/_macros.j2
+++ b/manala.ssh/templates/config/sshd/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.sudo/CHANGELOG.md
+++ b/manala.sudo/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.sudo/templates/sudoers/_macros.j2
+++ b/manala.sudo/templates/sudoers/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.supervisor/CHANGELOG.md
+++ b/manala.supervisor/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.4] - 2018-08-21
 ### Added

--- a/manala.supervisor/lookup_plugins/manala_supervisor_config.py
+++ b/manala.supervisor/lookup_plugins/manala_supervisor_config.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.six import string_types, iteritems
 from ansible.errors import AnsibleError
 
 class LookupModule(LookupBase):
@@ -12,7 +13,7 @@ class LookupModule(LookupBase):
             if isinstance(value, dict):
                 for envKey in sorted(value):
                     envValue = value.get(envKey)
-                    if not isinstance(envValue, (basestring, int, float)) or isinstance(envValue, bool):
+                    if not isinstance(envValue, (string_types, int, float)) or isinstance(envValue, bool):
                         raise AnsibleError("Expected a string, an integer or a float for key \"%s\" in manala supervisor config env" % envKey)
                     result.append("%s=\"%s\"" % (envKey, envValue))
             else:
@@ -30,7 +31,7 @@ class LookupModule(LookupBase):
         config = self._flatten(terms[0])
 
         for row in config:
-            for key, value in row.iteritems():
+            for key, value in iteritems(row):
                 if key == wantrow:
                     return self.format_row(key, value, wantrowtype)
 

--- a/manala.supervisor/lookup_plugins/manala_supervisor_configs.py
+++ b/manala.supervisor/lookup_plugins/manala_supervisor_configs.py
@@ -40,7 +40,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Expect a dict')
 
             # Check index key
-            if not config.has_key('file'):
+            if 'file' not in config:
                 raise AnsibleError('Expect "file" key')
 
             item = itemDefault.copy()

--- a/manala.supervisor/templates/config/_macros.j2
+++ b/manala.supervisor/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.supervisor/templates/config/default.dev.j2
+++ b/manala.supervisor/templates/config/default.dev.j2
@@ -8,7 +8,7 @@
 {% set config_include = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'unix_http_server' -%}
             {%- if config_unix_http_server.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'supervisord' -%}

--- a/manala.supervisor/templates/config/default.j2
+++ b/manala.supervisor/templates/config/default.j2
@@ -8,7 +8,7 @@
 {% set config_include = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'unix_http_server' -%}
             {%- if config_unix_http_server.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'supervisord' -%}

--- a/manala.supervisor/templates/config/default.prod.j2
+++ b/manala.supervisor/templates/config/default.prod.j2
@@ -8,7 +8,7 @@
 {% set config_include = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'unix_http_server' -%}
             {%- if config_unix_http_server.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'supervisord' -%}

--- a/manala.supervisor/templates/config/default.test.j2
+++ b/manala.supervisor/templates/config/default.test.j2
@@ -8,7 +8,7 @@
 {% set config_include = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'unix_http_server' -%}
             {%- if config_unix_http_server.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'supervisord' -%}

--- a/manala.supervisor/templates/configs/_macros.j2
+++ b/manala.supervisor/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.supervisor/templates/configs/app_program.dev.j2
+++ b/manala.supervisor/templates/configs/app_program.dev.j2
@@ -2,7 +2,7 @@
 
 {%- for configs in item.config|default([]) -%}
 
-    {%- for config_name, config in configs.iteritems() -%}
+    {%- for config_name, config in configs.items() -%}
 
 [program:{{ config_name }}]
 

--- a/manala.supervisor/templates/configs/app_program.prod.j2
+++ b/manala.supervisor/templates/configs/app_program.prod.j2
@@ -2,7 +2,7 @@
 
 {%- for configs in item.config|default([]) -%}
 
-    {%- for config_name, config in configs.iteritems() -%}
+    {%- for config_name, config in configs.items() -%}
 
 [program:{{ config_name }}]
 

--- a/manala.supervisor/templates/configs/app_program.test.j2
+++ b/manala.supervisor/templates/configs/app_program.test.j2
@@ -2,7 +2,7 @@
 
 {%- for configs in item.config|default([]) -%}
 
-    {%- for config_name, config in configs.iteritems() -%}
+    {%- for config_name, config in configs.items() -%}
 
 [program:{{ config_name }}]
 

--- a/manala.supervisor/templates/configs/program.dev.j2
+++ b/manala.supervisor/templates/configs/program.dev.j2
@@ -2,7 +2,7 @@
 
 {%- for configs in item.config|default([]) -%}
 
-    {%- for config_name, config in configs.iteritems() -%}
+    {%- for config_name, config in configs.items() -%}
 
 [program:{{ config_name }}]
 

--- a/manala.supervisor/templates/configs/program.prod.j2
+++ b/manala.supervisor/templates/configs/program.prod.j2
@@ -2,7 +2,7 @@
 
 {%- for configs in item.config|default([]) -%}
 
-    {%- for config_name, config in configs.iteritems() -%}
+    {%- for config_name, config in configs.items() -%}
 
 [program:{{ config_name }}]
 

--- a/manala.supervisor/templates/configs/program.test.j2
+++ b/manala.supervisor/templates/configs/program.test.j2
@@ -2,7 +2,7 @@
 
 {%- for configs in item.config|default([]) -%}
 
-    {%- for config_name, config in configs.iteritems() -%}
+    {%- for config_name, config in configs.items() -%}
 
 [program:{{ config_name }}]
 

--- a/manala.systemd/CHANGELOG.md
+++ b/manala.systemd/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Changed

--- a/manala.systemd/templates/system_configs/_macros.j2
+++ b/manala.systemd/templates/system_configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.systemd/templates/tmpfiles_config/_macros.j2
+++ b/manala.systemd/templates/tmpfiles_config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.telegraf/CHANGELOG.md
+++ b/manala.telegraf/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Added

--- a/manala.telegraf/templates/config/_macros.j2
+++ b/manala.telegraf/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.telegraf/templates/config/default.j2
+++ b/manala.telegraf/templates/config/default.j2
@@ -6,7 +6,7 @@
 {% set config_agent = [] -%}
 
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'global_tags' -%}
             {%- if config_global_tags.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'agent' -%}

--- a/manala.telegraf/templates/configs/_macros.j2
+++ b/manala.telegraf/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.telegraf/templates/configs/_tags.j2
+++ b/manala.telegraf/templates/configs/_tags.j2
@@ -2,7 +2,7 @@
 {% set config_tagpass = [] -%}
 {% set config_tagdrop = [] -%}
 {%- for configs in config -%}
-    {%- for config_name, config_parameters in configs.iteritems() -%}
+    {%- for config_name, config_parameters in configs.items() -%}
         {%- if config_name == 'tags' -%}
             {%- if config_tags.extend(config_parameters) -%}{%- endif -%}
         {%- elif config_name == 'tagpass' -%}

--- a/manala.thumbor/CHANGELOG.md
+++ b/manala.thumbor/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.1] - 2018-08-21
 ### Added

--- a/manala.thumbor/lookup_plugins/manala_thumbor_configs.py
+++ b/manala.thumbor/lookup_plugins/manala_thumbor_configs.py
@@ -40,7 +40,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Expect a dict')
 
             # Check index key
-            if not config.has_key('file'):
+            if 'file' not in config:
                 raise AnsibleError('Expect "file" key')
 
             item = itemDefault.copy()

--- a/manala.thumbor/templates/configs/_macros.j2
+++ b/manala.thumbor/templates/configs/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.varnish/CHANGELOG.md
+++ b/manala.varnish/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.3] - 2018-06-05
 ### Added

--- a/manala.varnish/templates/config/_macros.j2
+++ b/manala.varnish/templates/config/_macros.j2
@@ -4,7 +4,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -17,7 +17,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}

--- a/manala.vim/CHANGELOG.md
+++ b/manala.vim/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Python 3 compatibility
 
 ## [1.0.2] - 2018-06-05
 ### Added

--- a/manala.vim/templates/config/_macros.j2
+++ b/manala.vim/templates/config/_macros.j2
@@ -3,7 +3,7 @@
         {%- if parameter is string or parameter is number -%}
             {{ parameter }}{{ '\n' }}
         {%- elif parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key not in exclusions -%}
                     {{ _config_parameter(parameter_key, parameter_value, indent) }}{{ '\n' }}
                 {%- endif -%}
@@ -16,7 +16,7 @@
     {%- set vars = {'values': []} -%}
     {%- for parameter in parameters -%}
         {%- if parameter is mapping -%}
-            {%- for parameter_key, parameter_value in parameter.iteritems() -%}
+            {%- for parameter_key, parameter_value in parameter.items() -%}
                 {%- if parameter_key == key -%}
                     {%- if vars.update({'values': vars['values'] + [parameter_value]}) -%}{%- endif -%}
                 {%- endif -%}


### PR DESCRIPTION
- [x] `basestring` -> python six `string_types`
- [x] `dict.has_key('foo')` -> `'foo' in dict`
- [x] `dict.iteritems()` -> `dict.items()` (in jinja2 templates)
- [x] `dict.iteritems()` -> python six `iteritems(dict)`
- [x] `dict.keys()` -> `dict.keys()|list` (in jinja2 templates)
- [x] `dict.values()` -> `dict.values()|list` (in jinja2 templates)
- [x] `dict.keys()` -> `list(dict.keys())`
- [x] `dict.values()` -> `list(dict.values())`