### PR TITLE
[Skeleton] Disable docker.socket service handling via systemd

### DIFF
--- a/manala.skeleton/CHANGELOG.md
+++ b/manala.skeleton/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+# Removed
+- Disable docker.socket service handling via systemd, as it's no more reliable
+  starting from Docker CE 18.09.0 (See: https://github.com/docker/docker-ce-packaging/pull/257)
 
 ## [1.0.20] - 2018-10-12
 ### Added

--- a/manala.skeleton/vars/main.yml
+++ b/manala.skeleton/vars/main.yml
@@ -161,10 +161,6 @@ manala_skeleton_patterns:
           'name':    'docker.service',
           'enabled': False,
           'state':   'stopped'
-        },{
-          'name':    'docker.socket',
-          'enabled': True,
-          'state':   'started'
         }],
         []
       )


### PR DESCRIPTION
It's no more reliable starting from Docker CE 18.09.0 (See: https://github.com/docker/docker-ce-packaging/pull/257)