### PR TITLE
[Apt] Switch back problematics keys sources from ubuntu keyserver to direct url

### DIFF
--- a/manala.apt/CHANGELOG.md
+++ b/manala.apt/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Switch back problematics keys sources from ubuntu keyserver to direct url,
+  in order to work around strict ring checks introduced by gnupg2 2.1.18-8~deb9u3
+  on debian stretch (see: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=913614)
 
 ## [1.0.25] - 2018-10-31
 ### Added

--- a/manala.apt/vars/main.yml
+++ b/manala.apt/vars/main.yml
@@ -321,26 +321,26 @@ manala_apt_keys_patterns:
     url: http://deb.bearstech.com/bearstech-archive.gpg
     id: 90158EE0
   nodesource:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    url: http://deb.nodesource.com/gpgkey/nodesource.gpg.key
     id: 68576280
   mysql:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    url: https://repo.mysql.com/RPM-GPG-KEY-mysql
     id: 5072E1F5
   # Wheezy, Jessie
   mariadb_legacy:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    url: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
     id: 1BB943DB
   mariadb:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    url: https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/release/create_package_tarballs/deb_files/MariaDB-C74CD1D8-public.asc
     id: C74CD1D8
   maxscale_legacy:
-    url: https://downloads.mariadb.com/MaxScale/MariaDB-MaxScale-GPG-KEY
+    url: https://downloads.mariadb.com/MaxScale/old_key.public
     id: 8167EE24
   maxscale:
     keyserver: hkp://keyserver.ubuntu.com:80
     id: 28C12247
   postgresql:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     id: ACCC4CF8
   10gen:
     url: https://docs.mongodb.org/10gen-gpg-key.asc
@@ -420,7 +420,7 @@ manala_apt_keys_patterns:
     keyserver: hkp://keyserver.ubuntu.com:80
     id: E5267A6C
   percona:
-    keyserver: hkp://keyserver.ubuntu.com:80
+    url: https://github.com/percona/percona-repositories/raw/master/deb/percona-keyring2.gpg
     id: 8507EFA5
 
 # Preferences


### PR DESCRIPTION
This one was hard to catch...

Long story short, `gnupg2` package on debian stretch has been updated to `2.1.18-8~deb9u3`, introducing strict gpg ring checks. Some of the apt keys starts to gently warns...
This was not a big deal, those keys remains valids, except that gpg now log warnings on stdout, and `apt-key` script don't set `--batch` flags when running gpg, which would allowed to silence those warnings.
Still not a real issue, btw...
The fact is when running `apt-key` in a non interactive shell (like in a vagrant/ansible situation), `/dev/tty` is not available, and the import fails miserably...

This is easily reproducible, running such an ansible playbook:
```
- hosts: all
  vars:
    manala_apt_preferences:
      - nodejs@nodesource_4
      - mysql@mysql_5_6
      - mariadb@mariadb_10_2
      - maxscale@maxscale_2_1
      - postgresql@postgresql
      - percona@percona
  roles:
    - manala.apt

```
in a such non interactive manner:
```
sudo su -l [user] -c "ansible-playbook [playbook]"
```