### PR TITLE
[oauth2_proxy] Fix missing config extra vars

### DIFF
--- a/manala.oauth2-proxy/CHANGELOG.md
+++ b/manala.oauth2-proxy/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Add config extra vars
 
 ## [1.0.3] - 2018-10-17
 ### Fixed

--- a/manala.oauth2-proxy/templates/config/default.j2
+++ b/manala.oauth2-proxy/templates/config/default.j2
@@ -86,3 +86,32 @@
 {{ macros.config_row(config, 'skip_auth_regex', '# skip_auth_regex = [
 #     "/foo"
 # ]', 0, true) }}
+
+{{ macros.config(config, [
+  'http_address',
+  'https_address',
+  'tls_cert_file',
+  'tls_key_file',
+  'redirect_url',
+  'upstreams',
+  'request_logging',
+  'pass_basic_auth',
+  'pass_user_headers',
+  'pass_host_header',
+  'email_domains',
+  'client_id',
+  'client_secret',
+  'pass_access_token',
+  'authenticated_emails_file',
+  'htpasswd_file',
+  'custom_templates_dir',
+  'ssl_insecure_skip_verify',
+  'cookie_name',
+  'cookie_secret',
+  'cookie_domain',
+  'cookie_expire',
+  'cookie_refresh',
+  'cookie_secure',
+  'cookie_httponly',
+  'skip_auth_regex'
+]) -}}


### PR DESCRIPTION
Fix oauth2-proxy with github provider : 

```yaml
manala_oauth2_proxy_config:
  - http_address: "{{ ansible_eth0.ipv4.address }}:4280"
  - upstreams:
    - http://127.0.0.1:4440/
  - request_logging: true
  - provider: github
  - github_org: github_org
  - github_team: github_team
  - email_domains:
    - '*'
  - client_id: ****
  - client_secret: ****
  - pass_access_token: true
  - cookie_name: _oauth2_service
  - cookie_secret: ****
  - cookie_secure: true
  - cookie_httponly: true
  - cookie_expire: 168h
  - cookie_refresh: 1h
```