### PR TITLE
[Apt] Repository file can be specified

### DIFF
--- a/manala.apt/CHANGELOG.md
+++ b/manala.apt/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Repository file can be specified
 
 ## [1.0.26] - 2018-11-15
 ### Changed

--- a/manala.apt/lookup_plugins/manala_apt_repositories.py
+++ b/manala.apt/lookup_plugins/manala_apt_repositories.py
@@ -72,21 +72,23 @@ class LookupModule(LookupBase):
                     print(repository)
                     raise AnsibleError('Expect "source" key')
 
-            item.update({
-                'file': os.path.join(
-                    repositoriesDir,
-                    re.sub(
-                        '^deb (\\[.+\\] )?https?:\\/\\/([^ ]+)[ ].*$',
-                        '\\2',
-                        item['source']
+            # Force file if not present
+            if 'file' not in item:
+                item.update({
+                    'file': os.path.join(
+                        repositoriesDir,
+                        re.sub(
+                            '^deb (\\[.+\\] )?https?:\\/\\/([^ ]+)[ ].*$',
+                            '\\2',
+                            item['source']
+                        )
+                            .strip('/ ')
+                            .replace('.', '_')
+                            .replace('/', '_')
+                            .replace('-', '_')
+                            + '.list'
                     )
-                        .strip('/ ')
-                        .replace('.', '_')
-                        .replace('/', '_')
-                        .replace('-', '_')
-                        + '.list'
-                )
-            })
+                })
 
             items.append(item)
 

--- a/manala.apt/tests/0500_repositories.goss.1.yml
+++ b/manala.apt/tests/0500_repositories.goss.1.yml
@@ -7,7 +7,7 @@ file:
     filetype: file
     contains:
       - "deb http://deb.debian.org/debian {{ .Env.DISTRIBUTION_RELEASE }}-backports main"
-  /etc/apt/sources.list.d/packages_dotdeb_org.list:
+  /etc/apt/sources.list.d/dotdeb.list:
     exists:   true
     filetype: file
     contains:

--- a/manala.apt/vars/main.yml
+++ b/manala.apt/vars/main.yml
@@ -109,12 +109,15 @@ manala_apt_repositories_patterns:
   dotdeb:
     source: deb http://packages.dotdeb.org {{ ansible_distribution_release }} all
     key: dotdeb
+    file: dotdeb.list
   dotdeb_php55:
     source: deb http://packages.dotdeb.org wheezy-php55 all
     key: dotdeb
+    file: dotdeb_php55.list
   dotdeb_php56:
     source: deb http://packages.dotdeb.org wheezy-php56 all
     key: dotdeb
+    file: dotdeb_php56.list
   nginx:
     source: deb http://nginx.org/packages/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx
     key: nginx


### PR DESCRIPTION
This would help in some situations, like dotdeb repository, where automatic file name generator only take repository url into account, blocking multiple "flavors" by repository ("wheezy" and "wheezy-php56", for instance)