### PR TITLE
[Skeleton] Remove php-cs-fixer / phpcs / security-checker from PHP apps

### DIFF
--- a/manala.skeleton/CHANGELOG.md
+++ b/manala.skeleton/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+# Removed
+- Remove php-cs-fixer
+- Remove security-checker
 
 ## [1.0.27] - 2019-01-10
 ### Fixed

--- a/manala.skeleton/CHANGELOG.md
+++ b/manala.skeleton/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 # Removed
-- Remove php-cs-fixer
-- Remove security-checker
+- Remove default php applications (php-cs-fixer / phpcs / security-checker )
 
 ## [1.0.27] - 2019-01-10
 ### Fixed

--- a/manala.skeleton/vars/main.yml
+++ b/manala.skeleton/vars/main.yml
@@ -256,10 +256,6 @@ manala_skeleton_patterns:
     php_configs:
       - file: 50-xdebug.ini
         template: configs/xdebug.{{ manala_skeleton_env }}.j2
-    php_applications:
-      - php-cs-fixer
-      - phpcs
-      - security-checker
     # Nginx
     nginx_config_template: config/http.{{ manala_skeleton_env }}.j2
     nginx_configs_exclusive: true


### PR DESCRIPTION
Privilege in the projects the use of a php-cs-fix installed locally via Composer (`composer require friendsofphp/php-cs-fixer`)