### PR TITLE
[Skeleton] Both allow app passwordless mysql connections from localhost and anywhere

### DIFF
--- a/manala.skeleton/CHANGELOG.md
+++ b/manala.skeleton/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Both allow app passwordless mysql connections from localhost and anywhere
 
 ## [1.0.28] - 2019-01-25
 # Removed

--- a/manala.skeleton/vars/main.yml
+++ b/manala.skeleton/vars/main.yml
@@ -340,6 +340,10 @@ manala_skeleton_patterns:
     mysql_users:
       - name:     "{{ manala_skeleton_options.app.user }}"
         password: ~
+        host:     localhost
+        priv:     "*.*:ALL,GRANT"
+      - name:     "{{ manala_skeleton_options.app.user }}"
+        password: ~
         host:     "%"
         priv:     "*.*:ALL,GRANT"
     mysql_install_packages: "{{


### PR DESCRIPTION
According to the doc itself (https://dev.mysql.com/doc/refman/5.6/en/connecting.html):
> If the host is not specified or is localhost, a connection to the local host is assumed:
> On Unix, the client connects using a Unix socket file. The --socket option or the MYSQL_UNIX_PORT environment variable may be used to specify the socket name.

That's why we need to set *BOTH* app passwordless users, one for localhost, and one for anywhere (`%`)