### PR TITLE
Parametrize Debian/Ubuntu archive and security repo URLs

### DIFF
--- a/manala.apt/README.md
+++ b/manala.apt/README.md
@@ -53,6 +53,10 @@ None
 | `manala_apt_packages`                 | []                                                    | Array   | Collection of packages                 |
 | `manala_apt_cache_valid_time`         | 3600                                                  | Integer | Permitted age of apt cache, in seconds |
 | `manala_apt.update`                   | false                                                 | Boolean | Update packages                        |
+| `manala_apt_debian_archive_mirror`    | http://deb.debian.org/debian                          | String  | Debian archive repository mirror       |
+| `manala_apt_debian_security_mirror`   | http://security.debian.org                            | String  | Debian security repository mirror      |
+| `manala_apt_ubuntu_archive_mirror`    | http://archive.ubuntu.com/ubuntu                      | String  | Ubuntu archive repository mirror       |
+| `manala_apt_ubuntu_security_mirror`   | http://security.ubuntu.com/ubuntu                     | String  | Ubuntu security repository mirror      |
 
 ### Example
 

--- a/manala.apt/defaults/main.yml
+++ b/manala.apt/defaults/main.yml
@@ -10,6 +10,12 @@ manala_apt_install_packages_default:
 # Components
 manala_apt_components: ['main']
 
+# Mirrors
+manala_apt_debian_archive_mirror:  http://deb.debian.org/debian
+manala_apt_debian_security_mirror: http://security.debian.org
+manala_apt_ubuntu_archive_mirror:  http://archive.ubuntu.com/ubuntu
+manala_apt_ubuntu_security_mirror: http://security.ubuntu.com/ubuntu
+
 # Sources list
 manala_apt_sources_list_file:     /etc/apt/sources.list
 manala_apt_sources_list_template: ~

--- a/manala.apt/templates/sources_list/debian/default.j2
+++ b/manala.apt/templates/sources_list/debian/default.j2
@@ -2,5 +2,5 @@
 
 {% set config = manala_apt_sources_list -%}
 
-deb http://deb.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
 {{ macros.config(config) }}

--- a/manala.apt/templates/sources_list/debian/default_src.j2
+++ b/manala.apt/templates/sources_list/debian/default_src.j2
@@ -2,6 +2,6 @@
 
 {% set config = manala_apt_sources_list -%}
 
-deb http://deb.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-deb-src http://deb.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb-src {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
 {{ macros.config(config) }}

--- a/manala.apt/templates/sources_list/debian/security_updates.j2
+++ b/manala.apt/templates/sources_list/debian/security_updates.j2
@@ -2,7 +2,7 @@
 
 {% set config = manala_apt_sources_list -%}
 
-deb http://deb.debian.org/debian {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-deb http://security.debian.org {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
-deb http://deb.debian.org/debian {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+deb {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb {{ manala_apt_debian_security_mirror }} {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+deb {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
 {{ macros.config(config) }}

--- a/manala.apt/templates/sources_list/debian/security_updates_ovh.j2
+++ b/manala.apt/templates/sources_list/debian/security_updates_ovh.j2
@@ -3,6 +3,6 @@
 {% set config = manala_apt_sources_list -%}
 
 deb http://debian.mirrors.ovh.net/debian/ {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
-deb http://security.debian.org {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+deb {{ manala_apt_debian_security_mirror }} {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
 deb http://debian.mirrors.ovh.net/debian/ {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
 {{ macros.config(config) }}

--- a/manala.apt/templates/sources_list/ubuntu/default.j2
+++ b/manala.apt/templates/sources_list/ubuntu/default.j2
@@ -2,5 +2,5 @@
 
 {% set config = manala_apt_sources_list -%}
 
-deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
+deb {{ manala_apt_ubuntu_archive_mirror }} {{ ansible_distribution_release }} {{ manala_apt_components|join(' ') }}
 {{ macros.config(config) }}

--- a/manala.apt/vars/main.yml
+++ b/manala.apt/vars/main.yml
@@ -15,17 +15,17 @@ manala_apt_repositories_patterns:
   security: "{{
     {
       'debian': {
-        'source': 'deb http://security.debian.org ' ~ ansible_distribution_release ~ '/updates ' ~ manala_apt_components|join(' ')
+        'source': 'deb ' ~ manala_apt_debian_security_mirror ~ ' ' ~ ansible_distribution_release ~ '/updates ' ~ manala_apt_components|join(' ')
       },
       'ubuntu': {
-        'source': 'deb http://security.ubuntu.com/ubuntu ' ~ ansible_distribution_release ~ '-security ' ~ manala_apt_components|join(' ')
+        'source': 'deb ' ~ manala_apt_ubuntu_security_mirror ~ ' ' ~ ansible_distribution_release ~ '-security ' ~ manala_apt_components|join(' ')
       }
     }[ansible_distribution|lower]
   }}"
   security_src: "{{
     {
       'debian': {
-        'source': 'deb-src http://security.debian.org ' ~ ansible_distribution_release ~ '/updates ' ~ manala_apt_components|join(' ')
+        'source': 'deb-src ' ~ manala_apt_debian_security_mirror ~ ' ' ~ ansible_distribution_release ~ '/updates ' ~ manala_apt_components|join(' ')
       },
       'ubuntu': None
     }[ansible_distribution|lower]
@@ -33,17 +33,17 @@ manala_apt_repositories_patterns:
   updates: "{{
     {
       'debian': {
-        'source': 'deb http://deb.debian.org/debian ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
+        'source': 'deb ' ~ manala_apt_debian_archive_mirror ~ ' ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
       },
       'ubuntu': {
-        'source': 'deb http://archive.ubuntu.com/ubuntu ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
+        'source': 'deb ' ~ manala_apt_ubuntu_archive_mirror ~ ' ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
       }
     }[ansible_distribution|lower]
   }}"
   updates_src: "{{
     {
       'debian': {
-        'source': 'deb-src http://deb.debian.org/debian ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
+        'source': 'deb-src ' ~ manala_apt_debian_archive_mirror ~ ' ' ~ ansible_distribution_release ~ '-updates ' ~ manala_apt_components|join(' ')
       },
       'ubuntu': None
     }[ansible_distribution|lower]
@@ -59,11 +59,11 @@ manala_apt_repositories_patterns:
   backports: "{{
     {
       'debian': {
-        'source': 'deb http://deb.debian.org/debian ' ~ ansible_distribution_release ~ '-backports ' ~ manala_apt_components|join(' '),
+        'source': 'deb ' ~ manala_apt_debian_archive_mirror ~ ' ' ~ ansible_distribution_release ~ '-backports ' ~ manala_apt_components|join(' '),
         'pin':    'release a=' ~ ansible_distribution_release ~ '-backports'
       },
       'ubuntu': {
-        'source': 'deb http://archive.ubuntu.com/ubuntu ' ~ ansible_distribution_release ~ '-backports ' ~ manala_apt_components|join(' '),
+        'source': 'deb ' ~ manala_apt_ubuntu_archive_mirror ~ ' ' ~ ansible_distribution_release ~ '-backports ' ~ manala_apt_components|join(' '),
         'pin':    'release a=' ~ ansible_distribution_release ~ '-backports'
       }
     }[ansible_distribution|lower]
@@ -71,7 +71,7 @@ manala_apt_repositories_patterns:
   backports_sloppy: "{{
     {
       'debian': {
-        'source': 'deb http://deb.debian.org/debian ' ~ ansible_distribution_release ~ '-backports-sloppy ' ~ manala_apt_components|join(' '),
+        'source': 'deb ' ~ manala_apt_debian_archive_mirror ~ ' ' ~ ansible_distribution_release ~ '-backports-sloppy ' ~ manala_apt_components|join(' '),
         'pin':    'release a=' ~ ansible_distribution_release ~ '-backports-sloppy'
       },
       'ubuntu': None
@@ -79,32 +79,32 @@ manala_apt_repositories_patterns:
   }}"
   # Deprecated
   debian_security:
-    source: deb http://security.debian.org {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+    source: deb {{ manala_apt_debian_security_mirror }} {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
   # Deprecated
   debian_security_src:
-    source: deb-src http://security.debian.org {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
+    source: deb-src {{ manala_apt_debian_security_mirror }} {{ ansible_distribution_release }}/updates {{ manala_apt_components|join(' ') }}
   # Deprecated
   debian_updates:
-    source: deb http://deb.debian.org/debian {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+    source: deb {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
   # Deprecated
   debian_updates_src:
-    source: deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+    source: deb-src {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
   # Deprecated
   debian_backports:
-    source: deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports {{ manala_apt_components|join(' ') }}
+    source: deb {{ manala_apt_debian_archive_mirror }} {{ ansible_distribution_release }}-backports {{ manala_apt_components|join(' ') }}
     pin: release a={{ ansible_distribution_release }}-backports
   # Deprecated
   ubuntu_security:
-    source: deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security {{ manala_apt_components|join(' ') }}
+    source: deb {{ manala_apt_ubuntu_security_mirror }} {{ ansible_distribution_release }}-security {{ manala_apt_components|join(' ') }}
   # Deprecated
   ubuntu_updates:
-    source: deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
+    source: deb {{ manala_apt_ubuntu_archive_mirror }} {{ ansible_distribution_release }}-updates {{ manala_apt_components|join(' ') }}
   # Deprecated
   ubuntu_partner:
     source: deb http://archive.canonical.com/ubuntu {{ ansible_distribution_release }} partner
   # Deprecated
   ubuntu_backports:
-    source: deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-backports {{ manala_apt_components|join(' ') }}
+    source: deb {{ manala_apt_ubuntu_archive_mirror }} {{ ansible_distribution_release }}-backports {{ manala_apt_components|join(' ') }}
     pin: release a={{ ansible_distribution_release }}-backports
   dotdeb:
     source: deb http://packages.dotdeb.org {{ ansible_distribution_release }} all


### PR DESCRIPTION
You can use non-default Debian/Ubuntu mirrors by defining mirror
vars with defaults as follows.

manala_apt_debian_archive_mirror:  http://deb.debian.org/debian
manala_apt_debian_security_mirror: http://security.debian.org
manala_apt_ubuntu_archive_mirror:  http://archive.ubuntu.com/ubuntu
manala_apt_ubuntu_security_mirror: http://security.ubuntu.com/ubuntu