### PR TITLE
Signing keys has changed for Sury debian packages

### DIFF
--- a/manala.apt/vars/main.yml
+++ b/manala.apt/vars/main.yml
@@ -427,8 +427,7 @@ manala_apt_keys_patterns:
     }[ansible_distribution|lower]
   }}"
   # Deprecated
-  
-  _php_debian:
+  sury_php_debian:
     url: https://packages.sury.org/php/apt.gpg
     id: F4FCBB07
   # Deprecated

--- a/manala.apt/vars/main.yml
+++ b/manala.apt/vars/main.yml
@@ -418,7 +418,7 @@ manala_apt_keys_patterns:
     {
       'debian': {
         'url': 'https://packages.sury.org/php/apt.gpg',
-        'id':  '4A7A714D'
+        'id':  'F4FCBB07'
       },
       'ubuntu': {
         'keyserver': 'hkp://keyserver.ubuntu.com:80',
@@ -427,9 +427,10 @@ manala_apt_keys_patterns:
     }[ansible_distribution|lower]
   }}"
   # Deprecated
-  sury_php_debian:
+  
+  _php_debian:
     url: https://packages.sury.org/php/apt.gpg
-    id: 4A7A714D
+    id: F4FCBB07
   # Deprecated
   sury_php_ubuntu:
     keyserver: hkp://keyserver.ubuntu.com:80


### PR DESCRIPTION
https://twitter.com/debsuryorg/status/1107589606688677889
https://www.patreon.com/posts/dpa-new-signing-25451165?utm_medium=social&utm_source=twitter&utm_campaign=postshare

https://pgp.surfnet.nl/pks/lookup?op=vindex&fingerprint=on&search=0xb188e2b695bd4743

⚠️ I'm not sure I took the right key, please double check with the last link I pasted.