### PR TITLE
[Logrotate] Handle configs content

### DIFF
--- a/manala.logrotate/CHANGELOG.md
+++ b/manala.logrotate/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Handle configs content
 
 ## [1.0.5] - 2019-09-25
 ### Added

--- a/manala.logrotate/README.md
+++ b/manala.logrotate/README.md
@@ -59,6 +59,19 @@ manala_logrotate_configs:
         - notifempty
         - create: 0640 www-data adm
         - sharedscripts
+  - file: nginx_example_2
+    content: |
+      /var/log/nginx/example/*/*.log
+      /var/log/nginx/example/*/*/*.log {
+        size 200M
+        missingok
+        rotate 0
+        compress
+        delaycompress
+        notifempty
+        create 0640 www-data adm
+        sharedscripts
+      }
   - file: nginx_template
     template: logrotate/nginx.j2
   - file: nginx_absent

--- a/manala.logrotate/tasks/configs.yml
+++ b/manala.logrotate/tasks/configs.yml
@@ -11,7 +11,16 @@
     src:  "{{ item.template|default(manala_logrotate_configs_template|ternary(manala_logrotate_configs_template, 'configs/empty.j2')) }}"
     dest: "{{ manala_logrotate_configs_dir }}/{{ item.file }}"
   with_items: "{{ manala_logrotate_configs }}"
-  when: item.state|default('present') == 'present'
+  when: (item.state|default('present') == 'present')
+        and (item.content is not defined)
+
+- name: configs > Contents
+  copy:
+    content: "{{ item.content }}"
+    dest: "{{ manala_logrotate_configs_dir }}/{{ item.file }}"
+  with_items: "{{ manala_logrotate_configs }}"
+  when: (item.state|default('present') == 'present')
+        and (item.content is defined)
 
 - name: configs > Files absents
   file:

--- a/manala.logrotate/tests/0200_configs.goss.1.yml
+++ b/manala.logrotate/tests/0200_configs.goss.1.yml
@@ -3,7 +3,17 @@
 file:
   /etc/logrotate.d.test/foo:
     exists:   true
-    filetype: file
+    contains:
+      - /var/log/foo/*.log {
+  /etc/logrotate.d.test/foo_template:
+    exists: true
+    size: 1
+  /etc/logrotate.d.test/foo_content:
+    exists: true
+    contains:
+      - /var/log/foo/*.log {
+  /etc/logrotate.d.test/foo_template_content:
+    exists: true
     contains:
       - /var/log/foo/*.log {
   /etc/logrotate.d.test/bar:

--- a/manala.logrotate/tests/0200_configs.yml
+++ b/manala.logrotate/tests/0200_configs.yml
@@ -11,6 +11,21 @@
           - /var/log/foo/*.log:
             - rotate: 17
             - weekly
+      - file: foo_template
+        template: configs/empty.j2
+      - file: foo_content
+        content: |
+          /var/log/foo/*.log {
+            rotate 17
+            weekly
+          }
+      - file: foo_template_content
+        template: configs/empty.j2
+        content: |
+          /var/log/foo/*.log {
+            rotate 17
+            weekly
+          }
       - file: bar
         state: present
       - file: baz


### PR DESCRIPTION
Welcome to the hype:
```
manala_logrotate_configs:
  ...
  - file: nginx_example_2
    content: |
      /var/log/nginx/example/*/*.log
      /var/log/nginx/example/*/*/*.log {
        size 200M
        missingok
        rotate 0
        compress
        delaycompress
        notifempty
        create 0640 www-data adm
        sharedscripts
      }
```