### PR TITLE
[Telegraf] Remove check mode before restart

### DIFF
--- a/manala.telegraf/CHANGELOG.md
+++ b/manala.telegraf/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Remove check config before service restart
 
 ## [1.0.6] - 2019-06-18
 ### Fixed

--- a/manala.telegraf/handlers/main.yml
+++ b/manala.telegraf/handlers/main.yml
@@ -1,12 +1,6 @@
 ---
 
 - name: telegraf restart
-  command: "telegraf -config {{ manala_telegraf_config_file }} -config-directory {{ manala_telegraf_configs_dir }} -test"
-  changed_when: true
-  notify:
-    - do telegraf restart
-
-- name: do telegraf restart
   service:
     name:  telegraf
     state: restarted


### PR DESCRIPTION
Avoid to break when some services (nginx, php-fpm, ...) are not yet started or reloaded during provisioning.