### PR TITLE
[Apt] Drop GlusterFS arm64 support

### DIFF
--- a/roles/apt/CHANGELOG.md
+++ b/roles/apt/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- GlusterFS arm64 support
 
 ## [2.0.7] - 2020-02-13
 ### Added

--- a/roles/apt/vars/main.yml
+++ b/roles/apt/vars/main.yml
@@ -266,10 +266,10 @@ manala_apt_repositories_patterns:
     source: deb https://dl.bintray.com/obiba/deb all main
     key: mica
   glusterfs_6:
-    source: deb https://download.gluster.org/pub/gluster/glusterfs/6/LATEST/Debian/{{ ansible_distribution_release }}/{{ {'x86_64':'amd64','armv6l':'arm64'}[ansible_architecture] }}/apt {{ ansible_distribution_release }} main
+    source: deb https://download.gluster.org/pub/gluster/glusterfs/6/LATEST/Debian/{{ ansible_distribution_release }}/amd64/apt {{ ansible_distribution_release }} main
     key: glusterfs_6
   glusterfs_6_1:
-    source: deb https://download.gluster.org/pub/gluster/glusterfs/6/6.1/Debian/{{ ansible_distribution_release }}/{{ {'x86_64':'amd64','armv6l':'arm64'}[ansible_architecture] }}/apt {{ ansible_distribution_release }} main
+    source: deb https://download.gluster.org/pub/gluster/glusterfs/6/6.1/Debian/{{ ansible_distribution_release }}/amd64/apt {{ ansible_distribution_release }} main
     key: glusterfs_6
   haproxy_2_0:
     source: deb http://haproxy.debian.net {{ ansible_distribution_release }}-backports-2.0 main


### PR DESCRIPTION
Upstream `GlusterFS` debian repository include architecture (amd64|arm64) in its url.

```
https://download.gluster.org/pub/gluster/glusterfs/6/LATEST/Debian/stretch/amd64/apt stretch main
https://download.gluster.org/pub/gluster/glusterfs/6/LATEST/Debian/stretch/arm64/apt stretch main
```

For this reason, we have to consider `amd64` and `arm64` as two dstinct repositories.
To keep backward compatibility, main repository remains the `amd64` one.