### PR TITLE
[Php] Remove redundant HTTPS fastcgi parameter

### DIFF
--- a/roles/nginx/templates/configs/app_php_fpm.dev.j2
+++ b/roles/nginx/templates/configs/app_php_fpm.dev.j2
@@ -10,8 +10,7 @@
 ]) }}
 {{ macros.config_row(config, 'fastcgi_param', [
     'SCRIPT_FILENAME $realpath_root$fastcgi_script_name',
-    'DOCUMENT_ROOT $realpath_root',
-    'HTTPS $https if_not_empty'
+    'DOCUMENT_ROOT $realpath_root'
 ]) }}
 
 {{ macros.config(config, [

--- a/roles/nginx/templates/configs/app_php_fpm.prod.j2
+++ b/roles/nginx/templates/configs/app_php_fpm.prod.j2
@@ -10,8 +10,7 @@
 ]) }}
 {{ macros.config_row(config, 'fastcgi_param', [
     'SCRIPT_FILENAME $realpath_root$fastcgi_script_name',
-    'DOCUMENT_ROOT $realpath_root',
-    'HTTPS $https if_not_empty'
+    'DOCUMENT_ROOT $realpath_root'
 ]) }}
 
 {{ macros.config(config, [

--- a/roles/nginx/templates/configs/app_php_fpm.test.j2
+++ b/roles/nginx/templates/configs/app_php_fpm.test.j2
@@ -10,8 +10,7 @@
 ]) }}
 {{ macros.config_row(config, 'fastcgi_param', [
     'SCRIPT_FILENAME $realpath_root$fastcgi_script_name',
-    'DOCUMENT_ROOT $realpath_root',
-    'HTTPS $https if_not_empty'
+    'DOCUMENT_ROOT $realpath_root'
 ]) }}
 
 {{ macros.config(config, [


### PR DESCRIPTION
Every nginx packages (from debian or nginx) on every distributions (jessie/stretch/buster) already include `fastcgi_param HTTPS $https if_not_empty;` in `/etc/nginx/fastcgi_params` file.
No need to re-define it with the same value in our own templates :)