### PR TITLE
[MySQL] Omit users privileges if not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [MySQL] Omit users privileges if not defined
 
 ## [0.1.45] - 2020-06-23
 ### Changed

--- a/roles/mysql/CHANGELOG.md
+++ b/roles/mysql/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Omit users privileges if not defined
 
 ## [2.0.4] - 2020-06-09
 ### Changed

--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -107,23 +107,28 @@ manala_mysql_configs:
 
 ### Create mysql users
 
-```
+```yaml
 manala_mysql_users:
 
-  # Creates database user 'bob' and password '12345' with all database privileges and 'WITH GRANT OPTION'
-  - name: bob
+  # Creates database user 'foo' and password '12345' with all database privileges and 'WITH GRANT OPTION'
+  - name: foo
     password: 12345
     priv: '*.*:ALL,GRANT'
 
-  # Modify user Bob to require SSL connections. Note that REQUIRESSL is a special privilege that should only apply to *.* by itself.
-  - name: bob
+  # Modify user `bar` to require SSL connections. Note that REQUIRESSL is a special privilege that should only apply to *.* by itself.
+  - name: bar
     append_privs: true
     priv: '*.*:REQUIRESSL'
+
+  # Ensure user `baz@localhost` is absent.
+  - name: baz
+    host: localhost
+    state: absent
 ```
 
 ### Configure `my.cnf` example
 
-```
+```yaml
 # Create an alternative link for debian MySQL official packages
 manala_mysql_config_alternative: /etc/mysql/my.manala.cnf
 
@@ -136,7 +141,7 @@ manala_mysql_config:
 
 Be aware it will not clean your previous data directory nor migrate it.
 
-```
+```yaml
 manala_mysql_data_dir: /mnt/data
 
 # Required on mariadb

--- a/roles/mysql/tasks/users.yml
+++ b/roles/mysql/tasks/users.yml
@@ -5,7 +5,7 @@
     name:         "{{ item.name }}"
     password:     "{{ item.password|default(omit) }}"
     host:         "{{ item.host|default('localhost') }}"
-    priv:         "{{ item.priv }}"
+    priv:         "{{ item.priv|default(omit) }}"
     append_privs: "{{ item.append_privs|default(omit) }}"
     state:        "{{ item.state|default(omit) }}"
   with_items: "{{ manala_mysql_users }}"


### PR DESCRIPTION
In case of a simple `state: absent` user, privileges should not be required.