### PR TITLE
[Cron] Handle defaults parameters for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Cron] Handle defaults parameters for files
 
 ## [0.1.53] - 2020-07-07
 ### Changed

--- a/roles/cron/CHANGELOG.md
+++ b/roles/cron/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Handle defaults parameters for files
 
 ## [2.0.2] - 2020-02-13
 ### Added

--- a/roles/cron/README.md
+++ b/roles/cron/README.md
@@ -43,6 +43,7 @@ Using ansible galaxy requirements file:
 | -------------------------------------- | -------- | ----- | -------------------------------------- |
 | `manala_cron_install_packages`         | ~        | Array | Dependency packages to install         |
 | `manala_cron_install_packages_default` | ['cron'] | Array | Default dependency packages to install |
+| `manala_cron_files_defaults`           | {}       | Array | Defaults cron files parameters         |
 | `manala_cron_files`                    | []       | Array | Cron files collection                  |
 
 ### Configuration example
@@ -58,20 +59,33 @@ manala_cron_files:
       - BAR: bar
     jobs:
       # Do foo bar
-      - name:   foo-bar
-        job:    "php /srv/app/bin/console app:foo:bar"
+      - name: foo-bar
+        job: "php /srv/app/bin/console app:foo:bar"
         minute: 0
-        hour:   7
+        hour: 7
 ```
 
 ⚠️ In this example, you must **explicitly** set the minute option to `0` to have the job run at a specific hour, otherwise the default value `*` will run it _every minute_ for an hour.
+
+Using defaults:
+```yaml
+manala_cron_files_defaults:
+  user: bar # Will be applied by default to cron files
+manala_cron_files:
+  - file: app
+    jobs:
+      - name: foo-bar
+        job: "php /srv/app/bin/console app:foo:bar"
+        minute: 0
+        hour: 7
+```
 
 ## Example playbook
 
 ```yaml
 - hosts: servers
   roles:
-    - { role: manala.cron }
+    - role: manala.cron
 ```
 
 # Licence

--- a/roles/cron/defaults/main.yml
+++ b/roles/cron/defaults/main.yml
@@ -6,4 +6,6 @@ manala_cron_install_packages_default:
   - cron
 
 # Files
+manala_cron_files_defaults:
+  user: root
 manala_cron_files: []

--- a/roles/cron/handlers/main.yml
+++ b/roles/cron/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: cron restart
   service:
-    name:  cron
+    name: cron
     state: restarted

--- a/roles/cron/tasks/files.yml
+++ b/roles/cron/tasks/files.yml
@@ -10,7 +10,7 @@
     day:        "{{ item.1.day|default(omit) }}"
     month:      "{{ item.1.month|default(omit) }}"
     weekday:    "{{ item.1.weekday|default(omit) }}"
-    user:       "{{ item.0.user|default('root') }}"
+    user:       "{{ item.0.user|default(manala_cron_files_defaults.user) }}"
     state:      "{{ item.1.state|default('present') }}"
   with_subelements:
     - "{{ manala_cron_files }}"
@@ -24,7 +24,7 @@
     env:       true
     name:      "{{ item.name }}"
     value:     "{{ item.value }}"
-    user:      "{{ item.user|default('root') }}"
+    user:      "{{ item.user|default(manala_cron_files_defaults.user) }}"
     state:     present
   loop: "{{ query(
       'manala_cron_files_env',
@@ -41,7 +41,7 @@
     env:       true
     name:      "{{ (item.1.keys()|list)[0] }}"
     value:     "{{ (item.1.values()|list)[0] }}"
-    user:      "{{ item.0.user|default('root') }}"
+    user:      "{{ item.0.user|default(manala_cron_files_defaults.user) }}"
     state:     present
   with_subelements:
     - "{{ manala_cron_files }}"

--- a/roles/cron/tests/0100_install.yml
+++ b/roles/cron/tests/0100_install.yml
@@ -3,8 +3,11 @@
 - name: "{{ test }}"
   hosts: debian
   become: true
-  roles:
-    - manala.cron
-  post_tasks:
-    - name: Goss
-      command: goss --gossfile {{ test }}.goss.yml validate
+  tasks:
+
+    - block:
+        - import_role:
+            name: manala.cron
+      always:
+        - name: Goss
+          command: goss --gossfile {{ test }}.goss.yml validate

--- a/roles/cron/tests/0200_files.goss.yml
+++ b/roles/cron/tests/0200_files.goss.yml
@@ -1,6 +1,7 @@
 ---
 
 file:
+
   /etc/cron.d/foo:
     exists: true
     mode: "0644"
@@ -32,3 +33,23 @@ file:
       - 'QUX="qux"'
       - '#Ansible: baz-baz'
       - '0 7 * * * root cd /srv/app && bin/console app:baz:baz'
+
+  # Defaults
+  /etc/cron.d/qux:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+    contains:
+      - '#Ansible: foo-foo'
+      - '* * * * * qux whoami'
+  /etc/cron.d/quux:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+    contains:
+      - '#Ansible: foo-foo'
+      - '* * * * * quux whoami'

--- a/roles/cron/tests/0200_files.yml
+++ b/roles/cron/tests/0200_files.yml
@@ -3,37 +3,61 @@
 - name: "{{ test }}"
   hosts: debian
   become: true
-  vars:
-    manala_cron_files:
-      - file: foo
-        user: foo
-        # Deprecated
-        environment:
-          - FOO: foo
-        env:
-          BAR: bar
-        jobs:
-          - name:   foo-foo
-            job:    "cd /srv/app && bin/console app:foo:foo"
-            minute: 0
-            hour:   7
-      - file: bar
-        jobs:
-          - name:   bar-bar
-            job:    "cd /srv/app && bin/console app:bar:bar"
-            minute: 0
-            hour:   7
-      - file: baz
-        env:
-          BAR: bar
-          QUX: qux
-        jobs:
-          - name:   baz-baz
-            job:    "cd /srv/app && bin/console app:baz:baz"
-            minute: 0
-            hour:   7
-  roles:
-    - manala.cron
-  post_tasks:
-    - name: Goss
-      command: goss --gossfile {{ test }}.goss.yml validate
+  tasks:
+
+    - block:
+
+        - block:
+            - import_role:
+                name: manala.cron
+              vars:
+                manala_cron_files:
+                  - file: foo
+                    user: foo
+                    # Deprecated
+                    environment:
+                      - FOO: foo
+                    env:
+                      BAR: bar
+                    jobs:
+                      - name: foo-foo
+                        job: "cd /srv/app && bin/console app:foo:foo"
+                        minute: 0
+                        hour: 7
+                  - file: bar
+                    jobs:
+                      - name: bar-bar
+                        job: "cd /srv/app && bin/console app:bar:bar"
+                        minute: 0
+                        hour: 7
+                  - file: baz
+                    env:
+                      BAR: bar
+                      QUX: qux
+                    jobs:
+                      - name: baz-baz
+                        job: "cd /srv/app && bin/console app:baz:baz"
+                        minute: 0
+                        hour: 7
+
+        # Defaults
+        - block:
+            - import_role:
+                name: manala.cron
+              vars:
+                manala_cron_files_defaults:
+                  user: qux
+                manala_cron_files:
+                  - file: qux
+                    jobs:
+                      - name: foo-foo
+                        job: whoami
+                  - file: quux
+                    user: quux
+                    jobs:
+                      - name: foo-foo
+                        job: whoami
+
+      always:
+        - name: Goss
+          command: goss --gossfile {{ test }}.goss.yml validate

--- a/roles/cron/tests/0300_services.yml
+++ b/roles/cron/tests/0300_services.yml
@@ -3,8 +3,11 @@
 - name: "{{ test }}"
   hosts: debian
   become: true
-  roles:
-    - manala.cron
-  post_tasks:
-    - name: Goss
-      command: goss --gossfile {{ test }}.goss.yml validate
+  tasks:
+
+    - block:
+        - import_role:
+            name: manala.cron
+      always:
+        - name: Goss
+          command: goss --gossfile {{ test }}.goss.yml validate


### PR DESCRIPTION
```
manala_cron_files_defaults:
  user: qux # This will be applied by default to cron files
manala_cron_files:
  - file: qux
    jobs:
      - name: foo-foo
        job: whoami
  - file: quux
    user: quux # Override defaults
    jobs:
      - name: foo-foo
        job: whoami
```