### PR TITLE
[Ssh] Stop printing last log on dev/test server config template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [Ssh] Stop printing last log on dev/test server config template
 
 ## [0.1.54] - 2020-07-09
 ### Added

--- a/roles/ssh/CHANGELOG.md
+++ b/roles/ssh/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Stop printing last log on dev/test server config template
 
 ## [3.0.1] - 2020-06-23
 ### Changed

--- a/roles/ssh/templates/config/server/default.dev.j2
+++ b/roles/ssh/templates/config/server/default.dev.j2
@@ -11,6 +11,7 @@
 {{ macros.config_row(config, 'Subsystem', 'sftp /usr/lib/openssh/sftp-server') }}
 {{ macros.config_row(config, 'UsePAM', true) }}
 {{ macros.config_row(config, 'UseDNS', false) }}
+{{ macros.config_row(config, 'PrintLastLog', false) }}
 
 {{ macros.config(config, [
     'PermitRootLogin',
@@ -21,5 +22,6 @@
     'PrintMotd',
     'Subsystem',
     'UsePAM',
-    'UseDNS'
+    'UseDNS',
+    'PrintLastLog'
 ]) }}

--- a/roles/ssh/templates/config/server/default.test.j2
+++ b/roles/ssh/templates/config/server/default.test.j2
@@ -11,6 +11,7 @@
 {{ macros.config_row(config, 'Subsystem', 'sftp /usr/lib/openssh/sftp-server') }}
 {{ macros.config_row(config, 'UsePAM', true) }}
 {{ macros.config_row(config, 'UseDNS', false) }}
+{{ macros.config_row(config, 'PrintLastLog', false) }}
 
 {{ macros.config(config, [
     'PermitRootLogin',
@@ -21,5 +22,6 @@
     'PrintMotd',
     'Subsystem',
     'UsePAM',
-    'UseDNS'
+    'UseDNS',
+    'PrintLastLog'
 ]) }}


### PR DESCRIPTION
Bye bye messages on ssh connections:
```
Last login: Thu Jul  9 14:52:06 2020 from 10.0.2.2
```