### PR TITLE
[Docker] Allow applications templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Docker] Allow applications templates
 
 ## [0.1.60] - 2020-09-03
 ### Fixed

--- a/roles/docker/CHANGELOG.md
+++ b/roles/docker/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Allow applications templates
 
 ## [2.0.6] - 2020-08-26
 ### Changed

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -62,28 +62,30 @@ manala_docker_config_daemon:
 manala_docker_applications:
   - hello-world
   - application: npm
-    image:       node
-    command:     npm
-    tag:         alpine
+    image: node
+    command: npm
+    tag: alpine
+  - application: foo
+    template: docker/foo.j2
 
 manala_docker_containers:
-  - name:           postgres
-    image:          postgres:9.6
-    state:          started
+  - name: postgres
+    image: postgres:9.6
+    state: started
     restart_policy: unless-stopped
     env:
-      POSTGRES_USER:     foo
+      POSTGRES_USER: foo
       POSTGRES_PASSWORD: bar
-      POSTGRES_DB:       baz
-  - name:           memcached
-    image:          memcached:alpine
-    state:          started
+      POSTGRES_DB: baz
+  - name: memcached
+    image: memcached:alpine
+    state: started
     restart_policy: unless-stopped
-  - name:           elasticsearch
-    image:          docker.elastic.co/elasticsearch/elasticsearch:5.6.13
-    state:          started
+  - name: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.13
+    state: started
     restart_policy: unless-stopped
-    memory:         1g
+    memory: 1g
     ulimits:
       - memlock:-1:-1 # <type>:<soft>:<hard>    
 ```

--- a/roles/docker/lookup_plugins/manala_docker_applications.py
+++ b/roles/docker/lookup_plugins/manala_docker_applications.py
@@ -15,14 +15,14 @@ class LookupModule(LookupBase):
         patterns = terms[1]
 
         itemDefault = {
-            'tag':         None,
-            'rm':          None,
+            'tag': None,
+            'rm': None,
             'interactive': None,
-            'tty':         None,
-            'command':     None,
-            'volumes':     {},
+            'tty': None,
+            'command': None,
+            'volumes': {},
             'environment': {},
-            'workdir':     None
+            'workdir': None
         }
 
         for term in self._flatten(terms[0]):
@@ -34,7 +34,7 @@ class LookupModule(LookupBase):
                 item = itemDefault.copy()
 
                 item.update({
-                    'image':       term.split(':')[0],
+                    'image': term.split(':')[0],
                     'application': ((term.split('/')[1]).split(':')[0])
                         if len(term.split('/')) > 1 else
                     (term.split(':')[0])
@@ -58,9 +58,6 @@ class LookupModule(LookupBase):
                 # Check index key
                 if 'application' not in term:
                     raise AnsibleError('Expect "application" key')
-
-                if 'image' not in term:
-                    raise AnsibleError('Expect "image" key')
 
                 item = itemDefault.copy()
 

--- a/roles/docker/templates/applications/default.j2
+++ b/roles/docker/templates/applications/default.j2
@@ -27,7 +27,7 @@ docker run
   {%- endfor -%}
 {% endif -%}
 {%- if item.workdir %} --workdir {{ item.workdir }}{% endif -%}
-{{ ' ' }}{{ item.image }}
+{{ ' ' }}{{ item.image|mandatory }}
 {%- if item.tag %}:{{ item.tag }}{% endif -%}
 {%- if item.command %} {{ item.command }}{% endif -%}
 {{ ' ' }}"$@"

--- a/roles/docker/tests/0400_applications.goss.yml
+++ b/roles/docker/tests/0400_applications.goss.yml
@@ -13,6 +13,12 @@ file:
     owner: root
     group: root
     mode: "0755"
+  /usr/local/bin/audiowaveform:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0755"
 
 command:
   hello-world:
@@ -23,3 +29,8 @@ command:
   npm --version:
     exit-status: 0
     timeout: 60000
+  audiowaveform --version:
+    exit-status: 0
+    timeout: 60000
+    stdout:
+      - AudioWaveform v1.4.2

--- a/roles/docker/tests/0400_applications.yml
+++ b/roles/docker/tests/0400_applications.yml
@@ -12,6 +12,9 @@
         image: node
         command: npm
         tag: alpine
+      - application: audiowaveform
+        template: fixtures/applications/audiowaveform.j2
+        version: 1.4.2
   pre_tasks:
     - import_tasks: pre_tasks/docker.yml
   roles:

--- a/roles/docker/tests/fixtures/applications/audiowaveform.j2
+++ b/roles/docker/tests/fixtures/applications/audiowaveform.j2
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+docker run \
+  --rm \
+  elao/audiowaveform:{{ item.version|mandatory }} \
+  "$@"


### PR DESCRIPTION
`image` was previously a mandatory application parameter on the `lookup` level.

It's now on the template level, allowing to use templates where image is already hard defined.