### PR TITLE
[Apt] Handle holds with state (present|absent|ignore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [Apt] Handle holds by state (present|absent|ignore)
 
 ## [0.1.68] - 2020-10-09
 ### Added

--- a/roles/apt/CHANGELOG.md
+++ b/roles/apt/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add Mongodb 4.4 repositories
 
+### Changed
+- Handle holds by state (present|absent|ignore)
+
 ## [2.0.16] - 2020-10-06
 ### Added
 - Add 1.8 and 2.2 HAProxy repositories

--- a/roles/apt/README.md
+++ b/roles/apt/README.md
@@ -278,9 +278,15 @@ Handle your holded packages (the ones you don't want to upgrade) using:
 manala_apt_holds:
   - foo # Ensure "foo" package won't be upgraded
   - package: bar # The same with "bar" package, using verbose syntax
-    hold: true
+    state: present
   - package: baz # Ensure "baz" package *will* be upgraded
-    hold: false
+    state: absent
+  # Ignore hold
+  - package: qux
+    state: ignore
+  # Deprecated
+  - package: quux
+    hold: true # or false :)
 ```
 
 An exclusivity mode is also provided, to ensure *ALL* packages but the ones you set will be upgradable.

--- a/roles/apt/tasks/holds.yml
+++ b/roles/apt/tasks/holds.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: holds > Get selections
-  command: dpkg --get-selections
+- name: holds > Apt show holds
+  command: apt-mark showhold
   when: manala_apt_holds_exclusive
   register: __manala_apt_holds_exclusive_find
   changed_when: false
@@ -10,7 +10,7 @@
 - name: holds > Set selections
   dpkg_selections:
     name: "{{ item.package }}"
-    selection: "{{ item.hold|ternary('hold', 'install') }}"
+    selection: "{{ (item.state == 'present')|ternary('hold', 'install') }}"
   loop: "{{ query(
       'manala_apt_holds',
       manala_apt_holds,

--- a/roles/apt/tests/0700_holds.goss.yml
+++ b/roles/apt/tests/0700_holds.goss.yml
@@ -3,32 +3,38 @@
 # Default
 {{ if has "default" .Vars.tags }}
 command:
-  dpkg --get-selections:
+  apt-mark showhold:
     exit-status: 0
     stdout:
-      - "/^apt\t+hold$/"
-      - "/^dpkg\t+hold$/"
-      - "/^python\t+install$/"
+      - apt
+      - dpkg
+      - "!python"
+      - grep
+      - "!tar"
 {{ end }}
 
 # Hold
 {{ if has "hold" .Vars.tags }}
 command:
-  dpkg --get-selections:
+  apt-mark showhold:
     exit-status: 0
     stdout:
-      - "/^apt\t+hold$/"
-      - "/^dpkg\t+install$/"
-      - "/^python\t+hold$/"
+      - apt
+      - "!dpkg"
+      - python
+      - grep
+      - "!tar"
 {{ end }}
 
 # Exclusive
 {{ if has "exclusive" .Vars.tags }}
 command:
-  dpkg --get-selections:
+  apt-mark showhold:
     exit-status: 0
     stdout:
-      - "/^apt\t+install$/"
-      - "/^dpkg\t+hold$/"
-      - "/^python\t+install$/"
+      - "!apt"
+      - dpkg
+      - "!python"
+      - "!grep"
+      - "!tar"
 {{ end }}

--- a/roles/apt/tests/0700_holds.yml
+++ b/roles/apt/tests/0700_holds.yml
@@ -8,32 +8,59 @@
     # Default
     - tags: [default]
       block:
+        - dpkg_selections:
+            name: "{{ item }}"
+            selection: install
+          loop: [apt, dpkg, grep]
+        - dpkg_selections:
+            name: "{{ item }}"
+            selection: hold
+          loop: [python, tar]
         - import_role:
             name: manala.apt
           vars:
             manala_apt_holds:
+              # Short syntax
               - apt
+              # States
               - package: dpkg
-                hold: true
+                state: present
               - package: python
+                state: absent
+              # Deprecated
+              - package: grep
+                hold: true
+              - package: tar
                 hold: false
       always:
         - name: Goss
           command: >
             goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [default]}" validate
 
-    # Hold
-    - tags: [hold]
+    # State
+    - tags: [state]
       block:
+        - dpkg_selections:
+            name: "{{ item }}"
+            selection: install
+          loop: [apt, python, tar]
+        - dpkg_selections:
+            name: "{{ item }}"
+            selection: hold
+          loop: [dpkg, grep]
         - import_role:
             name: manala.apt
           vars:
             manala_apt_holds:
-              - apt
+              - package: apt
               - package: dpkg
-                hold: false
+                state: absent
               - package: python
-                hold: true
+                state: present
+              - package: grep
+                state: ignore
+              - package: tar
+                state: ignore
       always:
         - name: Goss
           command: >
@@ -45,13 +72,17 @@
         - dpkg_selections:
             name: "{{ item }}"
             selection: hold
-          loop: [apt, dpkg, python]
+          loop: [apt, dpkg, python, grep]
         - import_role:
             name: manala.apt
           vars:
             manala_apt_holds_exclusive: true
             manala_apt_holds:
-              - dpkg
+              - package: dpkg
+              - package: grep
+                state: ignore
+              - package: tar
+                state: ignore
       always:
         - name: Goss
           command: >


### PR DESCRIPTION
before:
```
manala_apt_holds:
  - package: bar
    hold: true
  - package: baz
    hold: false
```

after:
```
manala_apt_holds:
  - package: bar
    state: present
  - package: baz
    state: absent
```

`hold` flag is deprecated, but remains active to ensure backward compatibility