### PR TITLE
Release(s) with Github actions

### DIFF
--- a/.github/workflows/collection-release.yml
+++ b/.github/workflows/collection-release.yml
@@ -1,0 +1,59 @@
+---
+
+name: Collection Release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, 'Release')"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare Collection
+        run: make collection.prepare
+
+      - name: Build and Deploy Collection
+        uses: arillso/action.ansible.collection@master
+        with:
+          api_key: ${{ secrets.COLLECTION_API_TOKEN }}
+
+      - name: Retrieve version from galaxy.yml
+        id: get_version
+        uses: CumulusDS/get-yaml-paths-action@v0.1.0
+        with:
+          file: ./galaxy.yml
+          version: version
+
+      - name: Get Changelog Entry
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          path: ./CHANGELOG.md
+          version: ${{steps.get_version.outputs.version }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.version }}
+          release_name: manala-roles ${{ steps.changelog.outputs.version }}
+          body: ${{ steps.changelog.outputs.changes }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload_release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./manala-roles-${{ steps.changelog.outputs.version }}.tar.gz
+          asset_name: manala-roles-${{ steps.changelog.outputs.version }}.tar.gz
+          asset_content_type: application/zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,14 +87,6 @@ jobs:
         - make split CONFIRM=1
       if: branch = master AND type = push
 
-    - stage: collection
-      script:
-        - set -e
-        - make collection.prepare
-        - make collection.build
-        - make collection.publish
-      if: branch = master AND type = push AND commit_message = Release
-
 notifications:
   slack:
     secure: eLmB7407GORDp/9w55mwWm6slUHDdd6zamFOvfUBzu0EE2D3hnMnL6rebjQy+TXy5J0MAHokpMoldHCgfrOnr9Nj8orntGVDV8waIyMekEV55dbPFspW/skDE9Hq2d+NL1U5sDg57P4QzrKJ12msvFyed4wih+YFvhAUX419VKYzjQsj+XMqnsem0oOktpNoKENrOQM6GmNZSGG+Kjgg1XfybRNvEUN6mkBnbJH+SZCM0h/rNnluJItLjXiGG4ExZoKRdSOgb9ugjSSkTOu/x2tgdroKbtZhlYAbEuYCRugPfK/wCWmn6RfLfGjwDvbII7HHbjQ05vYe6BpbIERJhv5uSIg9YCJrunasEBHDG0C3wNWoEdeTwEE8YdFFbX2PiI21TT8FBD3ketLntgPOycya+Il2jBc51I1dQ7aA11E433YtCQyQVpV0Mywhy3Ra6t5nnOjyfG0DGwIrl5YqUgwah44dh96go9X2k75nLguD5q4bXE36th36x6VXp/4SBQg/15EWJhV1cRA+ypuIXV5Tiyvi9cxHmkdW8APSBUWo1ow3O3Q35gF4OYJvwc0ndqf81OfmWEAjeazIJTdO8xqxr+0dtP4WZ/lv+a+T9xwVqhAje+c4AYS8l5Yr887RjCzZtpW1NJGzH35Zu6BtB4Yh4gdoBJiGrN/gC/tK/Wg=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.83] - 2020-10-29
+### Changed
+- Nothing new from 0.1.82
+- This version is for test, but perfectly usable
+
 ## [0.1.82] - 2020-10-28
 ### Fixed
 - [Supervisor] `configs/inet_http_server.conf.j2` used old style macros

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: manala
 name: roles
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.82
+version: 0.1.83
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
- On lance le script prepare_collection.py

- On build et publish sur ansible-galaxy

- On parse la version dans galaxy.yml avec une action dédiée au yaml dans un step `get_version`

- On passe la version au step changelog qui couine si il ne l’a trouve pas

- On utilise la version du step changelog  pour créer et upload la release sur github, et non pas celui de get_version, comme ça on est sûr de jamais oublier le changelog