### PR TITLE
[Files] Fix task_vars issues

### DIFF
--- a/roles/files/action_plugins/manala_files_attributes.py
+++ b/roles/files/action_plugins/manala_files_attributes.py
@@ -76,7 +76,8 @@ class ActionModule(ActionBase):
                 parents_result = self._run_module(
                     'file',
                     {'path': os.path.dirname(path), 'state': 'directory'},
-                    task_args=['owner', 'group', 'mode'])
+                    task_args=['owner', 'group', 'mode'],
+                    task_vars=task_vars)
                 result['changed'] |= parents_result['changed']
                 result['diff'] += [parents_result['diff']]
 
@@ -152,7 +153,7 @@ class ActionModule(ActionBase):
 
                 # Force
                 if self._task.args.get('force'):
-                    link_stat = self._execute_remote_stat(path, {}, follow=False)
+                    link_stat = self._execute_remote_stat(path, task_vars, follow=False)
 
                     if link_stat['exists'] and not link_stat['islnk']:
                         absent_result = self._run_module(
@@ -178,7 +179,7 @@ class ActionModule(ActionBase):
 
                 # Force
                 if self._task.args.get('force'):
-                    link_stat = self._execute_remote_stat(path, {}, follow=True)
+                    link_stat = self._execute_remote_stat(path, task_vars, follow=True)
 
                     if link_stat['exists'] and not link_stat['isdir']:
                         absent_result = self._run_module(
@@ -204,7 +205,7 @@ class ActionModule(ActionBase):
 
                 # Force
                 if self._task.args.get('force'):
-                    link_stat = self._execute_remote_stat(path, {}, follow=True)
+                    link_stat = self._execute_remote_stat(path, task_vars, follow=True)
 
                     if link_stat['exists'] and not link_stat['isreg']:
                         absent_result = self._run_module(


### PR DESCRIPTION
If `task_vars` is not given as a parameter to some sub modules in attributes action plugin, important ansible variables such as `ansible_facts` could not be read.

This leads to issues like this:
```
TASK [manala.roles.files : attributes] *****************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'ansible_facts'
fatal: [development]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout": ""}
```

This fix simply ensure that `task_vars` are given in indentified situations.