### PR TITLE
[Haproxy] Force restart on change

### DIFF
--- a/roles/haproxy/handlers/main.yml
+++ b/roles/haproxy/handlers/main.yml
@@ -4,3 +4,8 @@
   service:
     name: haproxy
     state: reloaded
+
+- name: haproxy restart
+  service:
+    name: haproxy
+    state: restarted

--- a/roles/haproxy/tasks/environment.yml
+++ b/roles/haproxy/tasks/environment.yml
@@ -9,4 +9,4 @@
     mode: "0644"
   when: (manala_haproxy_environment_template is not none) or (manala_haproxy_environment|length)
   notify:
-    - haproxy reload
+    - haproxy restart


### PR DESCRIPTION
When the /etc/defaults/haproxy file is modified, haproxy needs a restart 
to pick up these changes. This implements just that.