### PR TITLE
[Skeleton] Configure default Node.js version to 14

### DIFF
--- a/roles/skeleton/defaults/main.yml
+++ b/roles/skeleton/defaults/main.yml
@@ -25,7 +25,7 @@ manala_skeleton_options:
   files: false
   mailhog: false
   nodejs: false
-  nodejs_version: "12" # '0.10'|'0.12'|'4'|'5'|'6'|'7'|'8'|'10'|'12'
+  nodejs_version: "14" # '0.10'|'0.12'|'4'|'5'|'6'|'7'|'8'|'10'|'12'|'14'
   npm: false
   yarn: false
   php: false


### PR DESCRIPTION
Node.js 14 support has been added in #505 but the default variable `nodejs_version` from skeleton role has not been updated.

I think it would be interesting to use Node.js 14 by default. 
WDYT?