### PR TITLE
[All] Switch from `eq` to more widely available `equalto` test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [Mount] Switch from `eq` to more widely available `equalto` test
+- [MySQL] Switch from `eq` to more widely available `equalto` test
+- [Systemd] Switch from `eq` to more widely available `equalto` test
 
 ## [0.1.97] - 2020-12-16
 ### Added

--- a/roles/mount/CHANGELOG.md
+++ b/roles/mount/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Switch from `eq` to more widely available `equalto` test
 
 ## [2.0.2] - 2020-11-09
 ### Added

--- a/roles/mount/tasks/points.yml
+++ b/roles/mount/tasks/points.yml
@@ -10,5 +10,5 @@
   loop: "{{
     manala_mount_points | flatten | selectattr('state', 'undefined') | list
     +
-    manala_mount_points | flatten | selectattr('state', 'defined') | rejectattr('state', 'eq', 'ignore') | list
+    manala_mount_points | flatten | selectattr('state', 'defined') | rejectattr('state', 'equalto', 'ignore') | list
   }}"

--- a/roles/mysql/CHANGELOG.md
+++ b/roles/mysql/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Switch from `eq` to more widely available `equalto` test
 
 ## [2.0.8] - 2020-12-15
 ### Added

--- a/roles/mysql/tasks/databases.yml
+++ b/roles/mysql/tasks/databases.yml
@@ -9,6 +9,6 @@
   loop: "{{
     manala_mysql_databases | flatten | selectattr('state', 'undefined') | list
     +
-    manala_mysql_databases | flatten | selectattr('state', 'defined') | rejectattr('state', 'eq', 'ignore') | list
+    manala_mysql_databases | flatten | selectattr('state', 'defined') | rejectattr('state', 'equalto', 'ignore') | list
   }}"
 

--- a/roles/mysql/tasks/users.yml
+++ b/roles/mysql/tasks/users.yml
@@ -11,5 +11,5 @@
   loop: "{{
     manala_mysql_users | flatten | selectattr('state', 'undefined') | list
     +
-    manala_mysql_users | flatten | selectattr('state', 'defined') | rejectattr('state', 'eq', 'ignore') | list
+    manala_mysql_users | flatten | selectattr('state', 'defined') | rejectattr('state', 'equalto', 'ignore') | list
   }}"

--- a/roles/systemd/CHANGELOG.md
+++ b/roles/systemd/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Switch from `eq` to more widely available `equalto` test
 
 ## [1.0.11] - 2020-11-09
 ### Added

--- a/roles/systemd/tasks/services.yml
+++ b/roles/systemd/tasks/services.yml
@@ -11,5 +11,5 @@
   loop: "{{
     manala_systemd_services | flatten | selectattr('state', 'undefined') | list
     +
-    manala_systemd_services | flatten | selectattr('state', 'defined') | rejectattr('state', 'eq', 'ignore') | list
+    manala_systemd_services | flatten | selectattr('state', 'defined') | rejectattr('state', 'equalto', 'ignore') | list
   }}"


### PR DESCRIPTION
`equalto` was introduced in jinja 2.8, `eq` in jinja 2.10, and default debian jinja package version in stretch is 2.8