### PR TITLE
[MySQL] Supports `sql_log_bin` directive on `manala_mysql_users`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [MySQL] Supports `sql_log_bin` directive on `manala_mysql_users`
 
 ## [0.1.103] - 2021-01-11
 ### Added

--- a/roles/mysql/CHANGELOG.md
+++ b/roles/mysql/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Supports `sql_log_bin` directive on `manala_mysql_users`
 
 ## [2.0.9] - 2020-12-17
 ### Changed

--- a/roles/mysql/README.md
+++ b/roles/mysql/README.md
@@ -159,6 +159,11 @@ manala_mysql_users:
     state: ignore
   # Flatten users
   - "{{ my_custom_users_array }}"
+  # Example of skipping binary logging while adding user
+  - name: foo
+    password: 12345
+    priv: '*.*:ALL,GRANT'
+    sql_log_bin: false
 ```
 
 ### Databases

--- a/roles/mysql/tasks/users.yml
+++ b/roles/mysql/tasks/users.yml
@@ -7,6 +7,7 @@
     host: "{{ item.host|default('localhost') }}"
     priv: "{{ item.priv|default(omit) }}"
     append_privs: "{{ item.append_privs|default(omit) }}"
+    sql_log_bin: "{{ item.sql_log_bin|default(omit) }}"
     state: "{{ item.state|default(omit) }}"
   loop: "{{
     manala_mysql_users | flatten | selectattr('state', 'undefined') | list


### PR DESCRIPTION
With `sql_log_bin: false` you can run `manala_mysql.users` on all cluster hosts without breaking log replication.