### PR TITLE
[Apt] Set last jessie repo for galera-3

### DIFF
--- a/roles/apt/CHANGELOG.md
+++ b/roles/apt/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add Galera_3_31 repository to set on Jessie (last version before deprecation)
 
 ## [2.0.23] - 2021-01-07
 ### Removed

--- a/roles/apt/vars/main.yml
+++ b/roles/apt/vars/main.yml
@@ -187,6 +187,9 @@ manala_apt_repositories_patterns:
   galera_3:
     source: deb {{ (ansible_distribution_release not in ['jessie'])|ternary('[trusted=yes] ','') }}http://releases.galeracluster.com/galera-3/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main
     key: galera
+  galera_3_31:
+    source: deb {{ (ansible_distribution_release not in ['jessie'])|ternary('[trusted=yes] ','') }}http://releases.galeracluster.com/galera-3.31/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main
+    key: galera
   mysql_wsrep_5_6:
     source: deb {{ (ansible_distribution_release not in ['jessie'])|ternary('[trusted=yes] ','') }}http://releases.galeracluster.com/mysql-wsrep-5.6/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main
     key: galera

--- a/roles/mysql/tests/pre_tasks/galera_3.yml
+++ b/roles/mysql/tests/pre_tasks/galera_3.yml
@@ -7,7 +7,7 @@
 
 - name: Pre tasks > Galera 3 apt repository
   apt_repository:
-    repo: deb {{ (ansible_distribution_release == 'stretch')|ternary('[trusted=yes] ','') }}http://releases.galeracluster.com/galera-3/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main
+    repo: deb {{ (ansible_distribution_release == 'stretch')|ternary('[trusted=yes] ','') }}http://releases.galeracluster.com/galera-{{ (ansible_distribution_release == 'jessie')|ternary('3.31','3') }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main
 
 - name: Pre tasks > Galera apt preferences
   copy:


### PR DESCRIPTION
Galera-3 deprecates Jessie from 3.32 (http://releases.galeracluster.com/galera-3/debian/dists/) 

This PR sets the apt source to the last version available on Jessie -> 3.31

(http://releases.galeracluster.com/galera-3.31/)