### PR TITLE
[TELEGRAF] Adding some input service configuration default templates

### DIFF
--- a/roles/telegraf/templates/configs/input_apache.conf.j2
+++ b/roles/telegraf/templates/configs/input_apache.conf.j2
@@ -1,0 +1,38 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = item.config|default([]) %}
+{% set section = 'inputs.apache' -%}
+
+# Read Apache status information (mod_status)
+[[{{ section }}]]
+  ## An array of URLs to gather from, must be directed at the machine
+  ## readable version of the mod_status page including the auto query string.
+  ## Default is "http://localhost/server-status?auto".
+  {{ macros.config_row(config, 'urls', ['http://localhost/server-status?auto']) }} 
+
+  ## Credentials for basic HTTP authentication.
+  {{ macros.config_row(config, 'username',  '# username = "myuser"', 0, true) }}
+  {{ macros.config_row(config, 'password',  '# password = "mypassword"', 0, true) }}
+
+  ## Maximum time to receive response.
+  {{ macros.config_row(config, 'response_timeout',  '# response_timeout = "5s"', 0, true) }}
+
+  ## Optional TLS Config
+  {{ macros.config_row(config, 'tls_ca', '# tls_ca = "/etc/telegraf/ca.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_cert', '# tls_cert = "/etc/telegraf/cert.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_key', '# tls_key = "/etc/telegraf/key.pem"', 0, true) }}
+  ## Use TLS but skip chain & host verification
+  {{ macros.config_row(config, 'insecure_skip_verify', '# insecure_skip_verify = false', 0, true) }}
+
+{{ macros.config(config, [
+  'urls',
+  'username',
+  'password',
+  'response_timeout',
+  'tls_ca',
+  'tls_cert',
+  'tls_key',
+  'insecure_skip_verify'
+], 2) }}
+
+{%- include '_tags.j2' %}

--- a/roles/telegraf/templates/configs/input_elasticsearch.conf.j2
+++ b/roles/telegraf/templates/configs/input_elasticsearch.conf.j2
@@ -1,0 +1,84 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = item.config|default([]) %}
+{% set section = 'inputs.elasticsearch' -%}
+
+[[inputs.elasticsearch]]
+  ## specify a list of one or more Elasticsearch servers
+  ## you can add username and password to your url to use basic authentication:
+  ## servers = ["http://user:pass@localhost:9200"]
+  {{ macros.config_row(config, 'servers', ['http://localhost:9200']) }}
+
+  ## Timeout for HTTP requests to the elastic search server(s)
+  {{ macros.config_row(config, 'http_timeout', "5s") }}
+
+  ## When local is true (the default), the node will read only its own stats.
+  ## Set local to false when you want to read the node stats from all nodes
+  ## of the cluster.
+  {{ macros.config_row(config, 'local', true) }}
+
+  ## Set cluster_health to true when you want to obtain cluster health stats
+  {{ macros.config_row(config, 'cluster_health', false) }}
+
+  ## Adjust cluster_health_level when you want to obtain detailed health stats
+  ## The options are
+  ##  - indices (default)
+  ##  - cluster
+  {{ macros.config_row(config, 'cluster_health_level', '# cluster_health_level = "indices"', 0, true) }}
+
+  ## Set cluster_stats to true when you want to obtain cluster stats.
+  {{ macros.config_row(config, 'cluster_stats', false) }}
+
+  ## Only gather cluster_stats from the master node. To work this require local = true
+  {{ macros.config_row(config, 'cluster_stats_only_from_master', true) }}
+
+  ## Indices to collect; can be one or more indices names or _all
+  ## Use of wildcards is allowed. Use a wildcard at the end to retrieve index names that end with a changing value, like a date.
+  {{ macros.config_row(config, 'indices_include', ["_all"]) }}
+
+  ## One of "shards", "cluster", "indices"
+  ## Currently only "shards" is implemented
+  {{ macros.config_row(config, 'indices_level', "shards") }}
+
+  ## node_stats is a list of sub-stats that you want to have gathered. Valid options
+  ## are "indices", "os", "process", "jvm", "thread_pool", "fs", "transport", "http",
+  ## "breaker". Per default, all stats are gathered.
+  # node_stats = ["jvm", "http"]
+  {{ macros.config_row(config, 'node_stats', '# node_stats = ["jvm", "http"]', 0, true) }}
+
+  ## HTTP Basic Authentication username and password.
+  {{ macros.config_row(config, 'username', '# username = ""', 0, true) }}
+  {{ macros.config_row(config, 'password', '# password = ""', 0, true) }}
+
+  ## Optional TLS Config
+  {{ macros.config_row(config, 'tls_ca', '# tls_ca = "/etc/telegraf/ca.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_cert', '# tls_cert = "/etc/telegraf/cert.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_key', '# tls_key = "/etc/telegraf/key.pem"', 0, true) }}
+  ## Use TLS but skip chain & host verification
+  {{ macros.config_row(config, 'insecure_skip_verify', '# insecure_skip_verify = false', 0, true) }}
+
+  ## Sets the number of most recent indices to return for indices that are configured with a date-stamped suffix.
+  ## Each 'indices_include' entry ending with a wildcard (*) or glob matching pattern will group together all indices that match it, and ## sort them by the date or number after the wildcard. Metrics then are gathered for only the 'num_most_recent_indices' amount of most ## recent indices.
+  {{ macros.config_row(config, 'num_most_recent_indices', '# num_most_recent_indices = 0', 0, true) }}
+
+{{ macros.config(config, [
+  'servers',
+  'http_timeout',
+  'local',
+  'cluster_health',
+  'cluster_health_level',
+  'cluster_stats',
+  'cluster_stats_only_from_master',
+  'indices_include',
+  'indices_level',
+  'node_stats',
+  'username',
+  'password',
+  'tls_ca',
+  'tls_cert',
+  'tls_key',
+  'insecure_skip_verify',
+  'num_most_recent_indices'
+], 2) }}
+
+{%- include '_tags.j2' %}

--- a/roles/telegraf/templates/configs/input_memcached.conf.j2
+++ b/roles/telegraf/templates/configs/input_memcached.conf.j2
@@ -1,0 +1,20 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = item.config|default([]) %}
+{% set section = 'inputs.memcached' -%}
+
+# Read metrics from one or many memcached servers.
+[[{{ section }}]]
+  # An array of address to gather stats about. Specify an ip on hostname
+  # with optional port. ie localhost, 10.0.0.1:11211, etc.
+  {{ macros.config_row(config, 'servers', ['localhost:11211']) }} 
+
+  # An array of unix memcached sockets to gather stats about.
+  {{ macros.config_row(config, 'unix_sockets', '# unix_sockets = ["/var/run/memcached.sock"]', 0, true) }}
+
+{{ macros.config(config, [
+  'servers',
+  'unix_sockets'
+], 2) }}
+
+{%- include '_tags.j2' %}

--- a/roles/telegraf/templates/configs/input_mongodb.conf.j2
+++ b/roles/telegraf/templates/configs/input_mongodb.conf.j2
@@ -1,0 +1,48 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = item.config|default([]) %}
+{% set section = 'inputs.mongodb' -%}
+
+[[inputs.mongodb]]
+  ## An array of URLs of the form:
+  ##   "mongodb://" [user ":" pass "@"] host [ ":" port]
+  ## For example:
+  ##   mongodb://user:auth_key@10.10.3.30:27017,
+  ##   mongodb://10.10.3.33:18832,
+  {{ macros.config_row(config, 'servers', ['mongodb://127.0.0.1:27017']) }}
+
+  ## When true, collect cluster status.
+  ## Note that the query that counts jumbo chunks triggers a COLLSCAN, which
+  ## may have an impact on performance.
+  {{ macros.config_row(config, 'gather_cluster_status', '# gather_cluster_status = true', 0, true) }}
+
+  ## When true, collect per database stats
+  {{ macros.config_row(config, 'gather_perdb_stats', '# gather_perdb_stats = false', 0, true) }}
+
+  ## When true, collect per collection stats
+  {{ macros.config_row(config, 'gather_col_stats', '# gather_col_stats = false', 0, true) }}
+
+  ## List of db where collections stats are collected
+  ## If empty, all db are concerned
+  {{ macros.config_row(config, 'col_stats_dbs', '# col_stats_dbs = ["local"]', 0, true) }}
+
+  ## Optional TLS Config
+  {{ macros.config_row(config, 'tls_ca', '# tls_ca = "/etc/telegraf/ca.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_cert', '# tls_cert = "/etc/telegraf/cert.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_key', '# tls_key = "/etc/telegraf/key.pem"', 0, true) }}
+  ## Use TLS but skip chain & host verification
+  {{ macros.config_row(config, 'insecure_skip_verify', '# insecure_skip_verify = false', 0, true) }}
+
+{{ macros.config(config, [
+  'servers',
+  'gather_cluster_status',
+  'gather_perdb_stats',
+  'gather_col_stats',
+  'col_stats_dbs',
+  'tls_ca',
+  'tls_cert',
+  'tls_key',
+  'insecure_skip_verify'
+], 2) }}
+
+{%- include '_tags.j2' %}

--- a/roles/telegraf/templates/configs/input_rabbitmq.conf.j2
+++ b/roles/telegraf/templates/configs/input_rabbitmq.conf.j2
@@ -1,0 +1,76 @@
+{%- import '_macros.j2' as macros with context -%}
+
+{% set config = item.config|default([]) %}
+{% set section = 'inputs.rabbitmq' -%}
+
+[[inputs.rabbitmq]]
+  ## Management Plugin url. (default: http://localhost:15672)
+  # url = "http://localhost:15672"
+  {{ macros.config_row(config, 'url', '# url = "http://localhost:15672"', 0, true) }}
+  ## Tag added to rabbitmq_overview series; deprecated: use tags
+  {{ macros.config_row(config, 'name', '# name = "rmq-server-1"', 0, true) }}
+  ## Credentials
+  {{ macros.config_row(config, 'username', '# username = "guest"', 0, true) }}
+  {{ macros.config_row(config, 'password', '# password = "guest"', 0, true) }}
+
+  ## Optional TLS Config
+  {{ macros.config_row(config, 'tls_ca', '# tls_ca = "/etc/telegraf/ca.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_cert', '# tls_cert = "/etc/telegraf/cert.pem"', 0, true) }}
+  {{ macros.config_row(config, 'tls_key', '# tls_key = "/etc/telegraf/key.pem"', 0, true) }}
+  ## Use TLS but skip chain & host verification
+  {{ macros.config_row(config, 'insecure_skip_verify', '# insecure_skip_verify = false', 0, true) }}
+
+  ## Optional request timeouts
+  ##
+  ## ResponseHeaderTimeout, if non-zero, specifies the amount of time to wait
+  ## for a server's response headers after fully writing the request.
+  {{ macros.config_row(config, 'header_timeout', '# header_timeout = "3s"', 0, true) }}
+  ##
+  ## client_timeout specifies a time limit for requests made by this client.
+  ## Includes connection time, any redirects, and reading the response body.
+  {{ macros.config_row(config, 'client_timeout', '# client_timeout = "4s"', 0, true) }}
+
+  ## A list of nodes to gather as the rabbitmq_node measurement. If not
+  ## specified, metrics for all nodes are gathered.
+  {{ macros.config_row(config, 'nodes', '# nodes = ["rabbit@node1", "rabbit@node2"]', 0, true) }}
+
+  ## A list of queues to gather as the rabbitmq_queue measurement. If not
+  ## specified, metrics for all queues are gathered.
+  {{ macros.config_row(config, 'queues', '# queues = ["telegraf"]', 0, true) }}
+
+  ## A list of exchanges to gather as the rabbitmq_exchange measurement. If not
+  ## specified, metrics for all exchanges are gathered.
+  {{ macros.config_row(config, 'exchanges', '# exchanges = ["telegraf"]', 0, true) }}
+
+  ## Queues to include and exclude. Globs accepted.
+  ## Note that an empty array for both will include all queues
+  {{ macros.config_row(config, 'queue_name_include', '# queue_name_include = []', 0, true) }}
+  {{ macros.config_row(config, 'queue_name_exclude', '# queue_name_exclude = []', 0, true) }}
+
+  ## Federation upstreams to include and exclude specified as an array of glob
+  ## pattern strings.  Federation links can also be limited by the queue and
+  ## exchange filters.
+  {{ macros.config_row(config, 'federation_upstream_include', '# federation_upstream_include = []', 0, true) }}
+  {{ macros.config_row(config, 'federation_upstream_exclude', '# federation_upstream_exclude = []', 0, true) }}
+
+{{ macros.config(config, [
+  'url',
+  'name',
+  'username',
+  'password',
+  'tls_ca',
+  'tls_cert',
+  'tls_key',
+  'insecure_skip_verify',
+  'header_timeout',
+  'client_timeout',
+  'nodes',
+  'queues',
+  'exchanges',
+  'queue_name_include',
+  'queue_name_exclude',
+  'federation_upstream_include',
+  'federation_upstream_exclude'
+], 2) }}
+
+{%- include '_tags.j2' %}


### PR DESCRIPTION
Creation of Telegraf input configuration default templates for services:

- Apache
- Elasticsearch
- MemcacheD
- MongoDB
- RabbitMQ