### PR TITLE
[sensu_go] Change default file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Sensu Go] Add file permissions variables
+
+### Changed
+- [Sensu Go] Change default file permissions to sensu:sensu - 0640
 
 ## [0.1.130] - 2021-06-18
 ### Changed

--- a/roles/sensu_go/CHANGELOG.md
+++ b/roles/sensu_go/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add file permissions variables
+
+### Changed
+- Change default file permissions to sensu:sensu - 0640
 
 ## [1.0.3] - 2020-08-28
 ### Changed

--- a/roles/sensu_go/defaults/main.yml
+++ b/roles/sensu_go/defaults/main.yml
@@ -15,11 +15,17 @@ manala_sensu_go_backend: false
 manala_sensu_go_backend_config_template: ~
 manala_sensu_go_backend_config_file: /etc/sensu/backend.yml
 manala_sensu_go_backend_config: {}
+manala_sensu_go_backend_owner: sensu
+manala_sensu_go_backend_group: sensu
+manala_sensu_go_backend_mode: "0640"
 
 # Agent Config
 manala_sensu_go_agent_config_template: ~
 manala_sensu_go_agent_config_file: /etc/sensu/agent.yml
 manala_sensu_go_agent_config: {}
+manala_sensu_go_agent_config_owner: sensu
+manala_sensu_go_agent_config_group: sensu
+manala_sensu_go_agent_config_mode: "0640"
 
 # Services
 manala_sensu_go_services: []

--- a/roles/sensu_go/tasks/agent_config.yml
+++ b/roles/sensu_go/tasks/agent_config.yml
@@ -4,8 +4,8 @@
   template:
     src: "agent_config/empty_agent.j2"
     dest: "{{ manala_sensu_go_agent_config_file }}"
-    owner: root
-    group: root
-    mode: "0644"
+    owner: "{{ manala_sensu_go_agent_config_owner }}"
+    group: "{{ manala_sensu_go_agent_config_group }}"
+    mode: "{{ manala_sensu_go_agent_config_mode }}"
   notify:
     - sensu-agent restart

--- a/roles/sensu_go/tasks/backend_config.yml
+++ b/roles/sensu_go/tasks/backend_config.yml
@@ -4,9 +4,9 @@
   template:
     src:  "backend_config/default_backend.j2"
     dest: "{{ manala_sensu_go_backend_config_file }}"
-    owner: root
-    group: root
-    mode: "0644"
+    owner: "{{ manala_sensu_go_backend_owner }}"
+    group: "{{ manala_sensu_go_backend_group }}"
+    mode: "{{ manala_sensu_go_backend_mode }}"
   when: manala_sensu_go_backend
   notify:
     - sensu-backend restart

--- a/roles/sensu_go/tests/0200_agent_config.goss.yml
+++ b/roles/sensu_go/tests/0200_agent_config.goss.yml
@@ -4,9 +4,9 @@ file:
   /etc/sensu/agent.yml:
     exists: true
     filetype: file
-    owner: root
-    group: root
-    mode: "0644"
+    owner: sensu
+    group: sensu
+    mode: "0640"
     contains:
       - "backend-url:"
       - "ws://127.0.0.1:8081"

--- a/roles/sensu_go/tests/0201_backend_config.goss.yml
+++ b/roles/sensu_go/tests/0201_backend_config.goss.yml
@@ -4,8 +4,8 @@ file:
   /etc/sensu/backend.yml:
     exists: true
     filetype: file
-    owner: root
-    group: root
-    mode: "0644"
+    owner: sensu
+    group: sensu
+    mode: "0640"
     contains:
       - "state-dir: /tmp"


### PR DESCRIPTION
Improve security by restricting sensu configs to `sensu` user/group only.