### PR TITLE
[Maxscale] Add support for 2.5 & 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Apt] Maxscale 2.5 support
+- [Apt] Maxscale 6.1 support
+- [Maxscale] MaxScale 2.5 support for Debian stretch and buster
+- [Maxscale] MaxScale 6.1 support for Debian stretch and buster
 
 ## [0.1.131] - 2021-09-02
 ### Added

--- a/roles/apt/CHANGELOG.md
+++ b/roles/apt/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Maxscale 2.5 support
+- Maxscale 6.1 support
 
 ## [2.0.31] - 2021-06-18
 ### Changed

--- a/roles/apt/vars/main.yml
+++ b/roles/apt/vars/main.yml
@@ -139,6 +139,12 @@ manala_apt_repositories_patterns:
   maxscale_2_4:
     source: deb https://downloads.mariadb.com/MaxScale/2.4/debian {{ ansible_distribution_release }} main
     key: mariadb_enterprise
+  maxscale_2_5:
+    source: deb https://downloads.mariadb.com/MaxScale/2.5/debian {{ ansible_distribution_release }} main
+    key: mariadb_enterprise
+  maxscale_6_1:
+    source: deb https://downloads.mariadb.com/MaxScale/6.1/debian {{ ansible_distribution_release }} main
+    key: mariadb_enterprise
   postgresql:
     source: deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main
     key: postgresql

--- a/roles/maxscale/CHANGELOG.md
+++ b/roles/maxscale/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- MaxScale 2.5 support for Debian stretch and buster
+- MaxScale 6.1 support for Debian stretch and buster
 
 ## [2.0.6] - 2020-12-09
 ### Removed
@@ -26,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.3] - 2020-03-12
 ### Added
-- MaxScale 2.4 support for Debian jessie, stretch and buster
+- MaxScale 2.4 support for Debian stretch and buster
 
 ## [2.0.2] - 2020-02-13
 ### Added

--- a/roles/maxscale/tests/0005_default.2.5.goss.yml
+++ b/roles/maxscale/tests/0005_default.2.5.goss.yml
@@ -1,0 +1,27 @@
+---
+
+package:
+  maxscale:
+    installed: true
+
+command:
+  maxscale --version:
+    exit-status: 0
+    stdout:
+      - "/^MaxScale 2.5.\\d+$/"
+  sudo maxctrl list users:
+    exit-status: 0
+    stdout:
+      - "/^│ admin │ inet │ admin      │$/"
+
+file:
+  /var/lib/maxscale/passwd:
+    exists: true
+    filetype: file
+    contains:
+      - '[{"name": "admin", "account": "admin", "password": "$6$MXS$RjtL0yWoXRIzkDGR6iwIAUHrQTWvqMizWYaGZKetqP2VDmWLgpgaT5YueeBoMKkoTMisvIy3sGEUMFa16UYDc."}]'
+
+service:
+  maxscale:
+    enabled: true
+    running: true

--- a/roles/maxscale/tests/0005_default.2.5.yml
+++ b/roles/maxscale/tests/0005_default.2.5.yml
@@ -1,0 +1,17 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - block:
+      - import_tasks: pre_tasks/maxscale_2.5.yml
+
+    - block:
+        - import_role:
+            name: manala.maxscale
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml validate

--- a/roles/maxscale/tests/0006_default.6.1.goss.yml
+++ b/roles/maxscale/tests/0006_default.6.1.goss.yml
@@ -1,0 +1,27 @@
+---
+
+package:
+  maxscale:
+    installed: true
+
+command:
+  maxscale --version:
+    exit-status: 0
+    stdout:
+      - "/^MaxScale 6.1.\\d+$/"
+  sudo maxctrl list users:
+    exit-status: 0
+    stdout:
+      - "/^│ admin │ inet │ admin      │$/"
+
+file:
+  /var/lib/maxscale/passwd:
+    exists: true
+    filetype: file
+    contains:
+      - '[{"name": "admin", "account": "admin", "password": "$6$MXS$RjtL0yWoXRIzkDGR6iwIAUHrQTWvqMizWYaGZKetqP2VDmWLgpgaT5YueeBoMKkoTMisvIy3sGEUMFa16UYDc."}]'
+
+service:
+  maxscale:
+    enabled: true
+    running: true

--- a/roles/maxscale/tests/0006_default.6.1.yml
+++ b/roles/maxscale/tests/0006_default.6.1.yml
@@ -1,0 +1,17 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - block:
+      - import_tasks: pre_tasks/maxscale_6.1.yml
+
+    - block:
+        - import_role:
+            name: manala.maxscale
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml validate

--- a/roles/maxscale/tests/0205_config.2.5.goss.yml
+++ b/roles/maxscale/tests/0205_config.2.5.goss.yml
@@ -1,0 +1,47 @@
+---
+
+file:
+  tmp/config/default:
+    exists: true
+    filetype: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tmp/config/default/default_deprecated.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[maxscale]"
+      - threads = auto
+      - "[Splitter Service]"
+      - type = service
+      - router = readwritesplit
+      - servers = mariadb-1, mariadb-2, mariadb-3
+      - user = maxscale
+      - passwd = XXXXXXXXXXXX
+  tmp/config/default/default_content.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[maxscale]"
+      - threads = auto
+      - "[Splitter Service]"
+      - type = service
+      - router = readwritesplit
+      - servers = mariadb-1, mariadb-2, mariadb-3
+      - user = maxscale
+      - passwd = XXXXXXXXXXXX
+  tmp/config/default/template.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Config maxscale"

--- a/roles/maxscale/tests/0205_config.2.5.yml
+++ b/roles/maxscale/tests/0205_config.2.5.yml
@@ -1,0 +1,56 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - block:
+      - import_tasks: pre_tasks/maxscale_2.5.yml
+
+    - block:
+        - file:
+            path: tmp/config/default
+            state: absent
+        # Default - Deprecated
+        - import_role:
+            # Play role fully on first run, so that handlers don't breaks
+            name: manala.maxscale
+          vars:
+            manala_maxscale_config_file: tmp/config/default/default_deprecated.cnf
+            manala_maxscale_config:
+              - maxscale:
+                - threads: auto # Dedicated container
+              - Splitter Service:
+                - type: service
+                - router: readwritesplit
+                - servers: mariadb-1, mariadb-2, mariadb-3
+                - user: maxscale
+                - passwd: XXXXXXXXXXXX
+        # Default - Content
+        - import_role:
+            name: manala.maxscale
+            tasks_from: config
+          vars:
+            manala_maxscale_config_file: tmp/config/default/default_content.cnf
+            manala_maxscale_config: |
+              [maxscale]
+              threads = auto
+
+              [Splitter Service]
+              type = service
+              router = readwritesplit
+              servers = mariadb-1, mariadb-2, mariadb-3
+              user = maxscale
+              passwd = XXXXXXXXXXXX
+        # Template
+        - import_role:
+            name: manala.maxscale
+            tasks_from: config
+          vars:
+            manala_maxscale_config_file: tmp/config/default/template.cnf
+            manala_maxscale_config_template: config/maxscale.cnf.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml validate

--- a/roles/maxscale/tests/0206_config.6.1.goss.yml
+++ b/roles/maxscale/tests/0206_config.6.1.goss.yml
@@ -1,0 +1,47 @@
+---
+
+file:
+  tmp/config/default:
+    exists: true
+    filetype: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tmp/config/default/default_deprecated.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[maxscale]"
+      - threads = auto
+      - "[Splitter Service]"
+      - type = service
+      - router = readwritesplit
+      - servers = mariadb-1, mariadb-2, mariadb-3
+      - user = maxscale
+      - passwd = XXXXXXXXXXXX
+  tmp/config/default/default_content.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[maxscale]"
+      - threads = auto
+      - "[Splitter Service]"
+      - type = service
+      - router = readwritesplit
+      - servers = mariadb-1, mariadb-2, mariadb-3
+      - user = maxscale
+      - passwd = XXXXXXXXXXXX
+  tmp/config/default/template.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Config maxscale"

--- a/roles/maxscale/tests/0206_config.6.1.yml
+++ b/roles/maxscale/tests/0206_config.6.1.yml
@@ -1,0 +1,56 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - block:
+      - import_tasks: pre_tasks/maxscale_6.1.yml
+
+    - block:
+        - file:
+            path: tmp/config/default
+            state: absent
+        # Default - Deprecated
+        - import_role:
+            # Play role fully on first run, so that handlers don't breaks
+            name: manala.maxscale
+          vars:
+            manala_maxscale_config_file: tmp/config/default/default_deprecated.cnf
+            manala_maxscale_config:
+              - maxscale:
+                - threads: auto # Dedicated container
+              - Splitter Service:
+                - type: service
+                - router: readwritesplit
+                - servers: mariadb-1, mariadb-2, mariadb-3
+                - user: maxscale
+                - passwd: XXXXXXXXXXXX
+        # Default - Content
+        - import_role:
+            name: manala.maxscale
+            tasks_from: config
+          vars:
+            manala_maxscale_config_file: tmp/config/default/default_content.cnf
+            manala_maxscale_config: |
+              [maxscale]
+              threads = auto
+
+              [Splitter Service]
+              type = service
+              router = readwritesplit
+              servers = mariadb-1, mariadb-2, mariadb-3
+              user = maxscale
+              passwd = XXXXXXXXXXXX
+        # Template
+        - import_role:
+            name: manala.maxscale
+            tasks_from: config
+          vars:
+            manala_maxscale_config_file: tmp/config/default/template.cnf
+            manala_maxscale_config_template: config/maxscale.cnf.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml validate

--- a/roles/maxscale/tests/0305_configs.2.5.goss.yml
+++ b/roles/maxscale/tests/0305_configs.2.5.goss.yml
@@ -1,0 +1,119 @@
+---
+
+# Default
+{{ if has "default" .Vars.tags }}
+file:
+  tmp/configs/default:
+    exists: true
+    filetype: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tmp/configs/default/default_deprecated.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[foo-1]"
+      - "type = server"
+      - "address = foo-1"
+      - "port = 3306"
+      - "protocol = MariaDBBackend"
+  tmp/configs/default/default_content.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[foo-1]"
+      - "type = server"
+      - "address = foo-1"
+      - "port = 3306"
+      - "protocol = MariaDBBackend"
+  tmp/configs/default/template.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs foo"
+{{ end }}
+
+# State
+{{ if has "state" .Vars.tags }}
+file:
+  tmp/configs/state/foo.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    size: 1
+  tmp/configs/state/bar.cnf:
+    exists: false
+  tmp/configs/state/baz.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    size: 1
+  tmp/configs/state/qux.cnf:
+    exists: true
+    filetype: file
+  tmp/configs/state/quux.cnf:
+    exists: false
+{{ end }}
+
+# Defaults
+{{ if has "defaults" .Vars.tags }}
+file:
+  tmp/configs/defaults/foo.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs foo"
+  tmp/configs/defaults/bar.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs bar"
+  tmp/configs/defaults/baz.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs bar"
+{{ end }}
+
+# Exclusive
+{{ if has "exclusive" .Vars.tags }}
+file:
+  tmp/configs/exclusive/foo.cnf:
+    exists: false
+  tmp/configs/exclusive/bar.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    size: 1
+  tmp/configs/exclusive/baz.cnf:
+    exists: false
+  tmp/configs/exclusive/qux.cnf:
+    exists: false
+  tmp/configs/exclusive/quux.cnf:
+    exists: false
+{{ end }}

--- a/roles/maxscale/tests/0305_configs.2.5.yml
+++ b/roles/maxscale/tests/0305_configs.2.5.yml
@@ -1,0 +1,130 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - tags: [always]
+      block:
+      - import_tasks: pre_tasks/maxscale_2.5.yml
+
+    # Default
+    - tags: [default]
+      block:
+        - file:
+            path: tmp/configs/default
+            state: absent
+        - import_role:
+            # Play role fully on first run, so that handlers don't breaks
+            name: manala.maxscale
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/default
+            manala_maxscale_configs:
+              # Default - Deprecated
+              - file: default_deprecated.cnf
+                config:
+                  - foo-1:
+                    - type: server
+                    - address: foo-1
+                    - port: 3306
+                    - protocol: MariaDBBackend
+              # Default - Content
+              - file: default_content.cnf
+                config: |
+                  [foo-1]
+                  type = server
+                  address = foo-1
+                  port = 3306
+                  protocol = MariaDBBackend
+              # Flatten
+              -
+                # Template
+                - file: template.cnf
+                  template: configs/foo.cnf.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [default]}" validate
+
+    # State
+    - tags: [state]
+      block:
+        - file:
+            path: tmp/configs/state
+            state: "{{ item }}"
+          loop: [absent, directory]
+        - file:
+            path: tmp/configs/state/{{ item }}.cnf
+            state: touch
+          loop: [bar, qux]
+        - import_role:
+            name: manala.maxscale
+            tasks_from: configs
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/state
+            manala_maxscale_configs:
+              - file: foo.cnf
+              - file: bar.cnf
+                state: absent
+              - file: baz.cnf
+                state: present
+              - file: qux.cnf
+                state: ignore
+              - file: quux.cnf
+                state: ignore
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [state]}" validate
+
+    # Defaults
+    - tags: [defaults]
+      block:
+        - file:
+            path: tmp/configs/defaults
+            state: absent
+        - import_role:
+            name: manala.maxscale
+            tasks_from: configs
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/defaults
+            manala_maxscale_configs_defaults:
+              template: configs/foo.cnf.j2
+            manala_maxscale_configs:
+              - file: foo.cnf
+              - template: configs/bar.cnf.j2
+              - file: baz.cnf
+                template: configs/bar.cnf.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [defaults]}" validate
+
+    # Exclusive
+    - tags: [exclusive]
+      block:
+        - file:
+            path: tmp/configs/exclusive
+            state: "{{ item }}"
+          loop: [absent, directory]
+        - file:
+            path: tmp/configs/exclusive/{{ item }}.cnf
+            state: touch
+          loop: [foo, bar, baz, qux]
+        - import_role:
+            name: manala.maxscale
+            tasks_from: configs
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/exclusive
+            manala_maxscale_configs_exclusive: true
+            manala_maxscale_configs:
+              - file: bar.cnf
+              - file: qux.cnf
+                state: ignore
+              - file: quux.cnf
+                state: ignore
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [exclusive]}" validate

--- a/roles/maxscale/tests/0306_configs.6.1.goss.yml
+++ b/roles/maxscale/tests/0306_configs.6.1.goss.yml
@@ -1,0 +1,119 @@
+---
+
+# Default
+{{ if has "default" .Vars.tags }}
+file:
+  tmp/configs/default:
+    exists: true
+    filetype: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tmp/configs/default/default_deprecated.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[foo-1]"
+      - "type = server"
+      - "address = foo-1"
+      - "port = 3306"
+      - "protocol = MariaDBBackend"
+  tmp/configs/default/default_content.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "[foo-1]"
+      - "type = server"
+      - "address = foo-1"
+      - "port = 3306"
+      - "protocol = MariaDBBackend"
+  tmp/configs/default/template.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs foo"
+{{ end }}
+
+# State
+{{ if has "state" .Vars.tags }}
+file:
+  tmp/configs/state/foo.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    size: 1
+  tmp/configs/state/bar.cnf:
+    exists: false
+  tmp/configs/state/baz.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    size: 1
+  tmp/configs/state/qux.cnf:
+    exists: true
+    filetype: file
+  tmp/configs/state/quux.cnf:
+    exists: false
+{{ end }}
+
+# Defaults
+{{ if has "defaults" .Vars.tags }}
+file:
+  tmp/configs/defaults/foo.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs foo"
+  tmp/configs/defaults/bar.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs bar"
+  tmp/configs/defaults/baz.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    contains:
+      - "Configs bar"
+{{ end }}
+
+# Exclusive
+{{ if has "exclusive" .Vars.tags }}
+file:
+  tmp/configs/exclusive/foo.cnf:
+    exists: false
+  tmp/configs/exclusive/bar.cnf:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0644"
+    size: 1
+  tmp/configs/exclusive/baz.cnf:
+    exists: false
+  tmp/configs/exclusive/qux.cnf:
+    exists: false
+  tmp/configs/exclusive/quux.cnf:
+    exists: false
+{{ end }}

--- a/roles/maxscale/tests/0306_configs.6.1.yml
+++ b/roles/maxscale/tests/0306_configs.6.1.yml
@@ -1,0 +1,130 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - tags: [always]
+      block:
+      - import_tasks: pre_tasks/maxscale_6.1.yml
+
+    # Default
+    - tags: [default]
+      block:
+        - file:
+            path: tmp/configs/default
+            state: absent
+        - import_role:
+            # Play role fully on first run, so that handlers don't breaks
+            name: manala.maxscale
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/default
+            manala_maxscale_configs:
+              # Default - Deprecated
+              - file: default_deprecated.cnf
+                config:
+                  - foo-1:
+                    - type: server
+                    - address: foo-1
+                    - port: 3306
+                    - protocol: MariaDBBackend
+              # Default - Content
+              - file: default_content.cnf
+                config: |
+                  [foo-1]
+                  type = server
+                  address = foo-1
+                  port = 3306
+                  protocol = MariaDBBackend
+              # Flatten
+              -
+                # Template
+                - file: template.cnf
+                  template: configs/foo.cnf.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [default]}" validate
+
+    # State
+    - tags: [state]
+      block:
+        - file:
+            path: tmp/configs/state
+            state: "{{ item }}"
+          loop: [absent, directory]
+        - file:
+            path: tmp/configs/state/{{ item }}.cnf
+            state: touch
+          loop: [bar, qux]
+        - import_role:
+            name: manala.maxscale
+            tasks_from: configs
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/state
+            manala_maxscale_configs:
+              - file: foo.cnf
+              - file: bar.cnf
+                state: absent
+              - file: baz.cnf
+                state: present
+              - file: qux.cnf
+                state: ignore
+              - file: quux.cnf
+                state: ignore
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [state]}" validate
+
+    # Defaults
+    - tags: [defaults]
+      block:
+        - file:
+            path: tmp/configs/defaults
+            state: absent
+        - import_role:
+            name: manala.maxscale
+            tasks_from: configs
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/defaults
+            manala_maxscale_configs_defaults:
+              template: configs/foo.cnf.j2
+            manala_maxscale_configs:
+              - file: foo.cnf
+              - template: configs/bar.cnf.j2
+              - file: baz.cnf
+                template: configs/bar.cnf.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [defaults]}" validate
+
+    # Exclusive
+    - tags: [exclusive]
+      block:
+        - file:
+            path: tmp/configs/exclusive
+            state: "{{ item }}"
+          loop: [absent, directory]
+        - file:
+            path: tmp/configs/exclusive/{{ item }}.cnf
+            state: touch
+          loop: [foo, bar, baz, qux]
+        - import_role:
+            name: manala.maxscale
+            tasks_from: configs
+          vars:
+            manala_maxscale_configs_dir: tmp/configs/exclusive
+            manala_maxscale_configs_exclusive: true
+            manala_maxscale_configs:
+              - file: bar.cnf
+              - file: qux.cnf
+                state: ignore
+              - file: quux.cnf
+                state: ignore
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml --vars-inline "{tags: [exclusive]}" validate

--- a/roles/maxscale/tests/0405_users.2.5.goss.yml
+++ b/roles/maxscale/tests/0405_users.2.5.goss.yml
@@ -1,0 +1,28 @@
+---
+
+file:
+  tmp/users/default/default:
+    exists: true
+    filetype: file
+    owner: maxscale
+    group: maxscale
+    mode: "0600"
+    contains:
+      - '[{"account": "admin", "password": "$1$MXS$ilOCSZPnjmHjTz6B96SiJ1", "name": "foo"},{"account": "admin", "password": "$1$MXS$M.YZOr2pNTgW87l7KQWLU/", "name": "bar"}]'
+  tmp/users/default/empty:
+    exists: true
+    filetype: file
+    owner: maxscale
+    group: maxscale
+    mode: "0600"
+    size: 2
+    contains:
+      - '[]'
+  tmp/users/default/template:
+    exists: true
+    filetype: file
+    owner: maxscale
+    group: maxscale
+    mode: "0600"
+    contains:
+      - Users maxscale

--- a/roles/maxscale/tests/0405_users.2.5.yml
+++ b/roles/maxscale/tests/0405_users.2.5.yml
@@ -1,0 +1,44 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - block:
+      - import_tasks: pre_tasks/maxscale_2.5.yml
+
+    - block:
+        - file:
+            path: tmp/users/default
+            state: "{{ item }}"
+          loop: [absent, directory]
+        # Default
+        - import_role:
+            # Play role fully on first run, so that handlers don't breaks
+            name: manala.maxscale
+          vars:
+            manala_maxscale_users_file: tmp/users/default/default
+            manala_maxscale_network_users:
+              - name: foo
+                password: $1$MXS$ilOCSZPnjmHjTz6B96SiJ1 # "foo"
+              - name: bar
+                password: $1$MXS$M.YZOr2pNTgW87l7KQWLU/ # "bar"
+        # Empty
+        - import_role:
+            name: manala.maxscale
+            tasks_from: users
+          vars:
+            manala_maxscale_users_file: tmp/users/default/empty
+            manala_maxscale_network_users: []
+        # Template
+        - import_role:
+            name: manala.maxscale
+            tasks_from: users
+          vars:
+            manala_maxscale_users_file: tmp/users/default/template
+            manala_maxscale_users_template: users/passwd.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml validate

--- a/roles/maxscale/tests/0406_users.6.1.goss.yml
+++ b/roles/maxscale/tests/0406_users.6.1.goss.yml
@@ -1,0 +1,28 @@
+---
+
+file:
+  tmp/users/default/default:
+    exists: true
+    filetype: file
+    owner: maxscale
+    group: maxscale
+    mode: "0600"
+    contains:
+      - '[{"account": "admin", "password": "$1$MXS$ilOCSZPnjmHjTz6B96SiJ1", "name": "foo"},{"account": "admin", "password": "$1$MXS$M.YZOr2pNTgW87l7KQWLU/", "name": "bar"}]'
+  tmp/users/default/empty:
+    exists: true
+    filetype: file
+    owner: maxscale
+    group: maxscale
+    mode: "0600"
+    size: 2
+    contains:
+      - '[]'
+  tmp/users/default/template:
+    exists: true
+    filetype: file
+    owner: maxscale
+    group: maxscale
+    mode: "0600"
+    contains:
+      - Users maxscale

--- a/roles/maxscale/tests/0406_users.6.1.yml
+++ b/roles/maxscale/tests/0406_users.6.1.yml
@@ -1,0 +1,44 @@
+---
+
+- name: "{{ test }}"
+  hosts: debian:!debian.jessie
+  become: true
+  tasks:
+
+    - block:
+      - import_tasks: pre_tasks/maxscale_6.1.yml
+
+    - block:
+        - file:
+            path: tmp/users/default
+            state: "{{ item }}"
+          loop: [absent, directory]
+        # Default
+        - import_role:
+            # Play role fully on first run, so that handlers don't breaks
+            name: manala.maxscale
+          vars:
+            manala_maxscale_users_file: tmp/users/default/default
+            manala_maxscale_network_users:
+              - name: foo
+                password: $1$MXS$ilOCSZPnjmHjTz6B96SiJ1 # "foo"
+              - name: bar
+                password: $1$MXS$M.YZOr2pNTgW87l7KQWLU/ # "bar"
+        # Empty
+        - import_role:
+            name: manala.maxscale
+            tasks_from: users
+          vars:
+            manala_maxscale_users_file: tmp/users/default/empty
+            manala_maxscale_network_users: []
+        # Template
+        - import_role:
+            name: manala.maxscale
+            tasks_from: users
+          vars:
+            manala_maxscale_users_file: tmp/users/default/template
+            manala_maxscale_users_template: users/passwd.j2
+      always:
+        - name: Goss
+          command: >
+            goss --gossfile {{ test }}.goss.yml validate

--- a/roles/maxscale/tests/pre_tasks/maxscale_2.5.yml
+++ b/roles/maxscale/tests/pre_tasks/maxscale_2.5.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Pre tasks > Maxscale (MariaDB) apt key
+  apt_key:
+    file: pre_tasks/apt_keys/mariadb_entreprise.gpg
+    id: E3C94F49
+
+- name: Pre tasks > Maxscale (MariaDB) 2.5 apt repository
+  apt_repository:
+    repo: deb https://downloads.mariadb.com/MaxScale/2.5/debian {{ ansible_distribution_release }} main

--- a/roles/maxscale/tests/pre_tasks/maxscale_6.1.yml
+++ b/roles/maxscale/tests/pre_tasks/maxscale_6.1.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Pre tasks > Maxscale (MariaDB) apt key
+  apt_key:
+    file: pre_tasks/apt_keys/mariadb_entreprise.gpg
+    id: E3C94F49
+
+- name: Pre tasks > Maxscale (MariaDB) 6.1 apt repository
+  apt_repository:
+    repo: deb https://downloads.mariadb.com/MaxScale/6.1/debian {{ ansible_distribution_release }} main


### PR DESCRIPTION
Skipping version 6.0 since it's labelled as `beta` https://mariadb.com/kb/en/mariadb-maxscale-6-mariadb-maxscale-60-release-notes-2021-06-30/