### PR TITLE
[Composer ] No interaction on install check to prevent blocking root warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Composer] No interaction on install check to prevent blocking root warning
 
 ## [1.0.3] - 2022-01-10
 ### Fixed

--- a/roles/composer/tasks/install.yml
+++ b/roles/composer/tasks/install.yml
@@ -11,7 +11,7 @@
 
 - name: install > Check
   command: >
-    {{ manala_composer_bin }} --version
+    {{ manala_composer_bin }} --version -n
   register: __manala_composer_bin_check_result
   changed_when: false
   failed_when: false

--- a/roles/composer/tasks/install.yml
+++ b/roles/composer/tasks/install.yml
@@ -11,7 +11,7 @@
 
 - name: install > Check
   command: >
-    {{ manala_composer_bin }} --version -n
+    {{ manala_composer_bin }} --version --no-interaction
   register: __manala_composer_bin_check_result
   changed_when: false
   failed_when: false


### PR DESCRIPTION
Composer display a blocking warning when running in sudo mode:

<img width="919" alt="Capture d’écran 2022-01-12 à 11 33 27" src="https://user-images.githubusercontent.com/1846873/149126238-55092a66-ac79-4e1d-bf79-1fc4f7a01b79.png">

The prevent the "install > Check" step from ever finishing.
The add of the "-n" (no-interaction) option fixes the problem.