### PR TITLE
[Apt] Trust MySQL repository on stretch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Changed
+- [Apt] Trust MySQL repository on stretch
 
 ## [1.0.9] - 2022-02-21
 ## Changed

--- a/plugins/lookup/apt_keys.py
+++ b/plugins/lookup/apt_keys.py
@@ -28,8 +28,9 @@ class LookupModule(LookupBase):
 
         # Handle repositories defined as reversed preferences
         for repository in repositories[::-1]:
-            if 'key' in repository:
-                keys.insert(0, repository.get('key'))
+            key = repository.get('key')
+            if key:
+                keys.insert(0, key)
 
         for key in keys:
 

--- a/roles/apt/vars/main.yml
+++ b/roles/apt/vars/main.yml
@@ -77,14 +77,20 @@ manala_apt_repositories_patterns:
     source: deb https://deb.nodesource.com/node_16.x {{ ansible_distribution_release }} main
     key: nodesource
   mysql_5_6:
-    source: deb http://repo.mysql.com/apt/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} mysql-5.6
-    key: "{{ (ansible_distribution_release in ['stretch'])|ternary('mysql_legacy', 'mysql')}}"
+    source: >-
+      {{ (ansible_distribution_release in ['stretch'])|ternary('deb [trusted=yes]', 'deb') }}
+      http://repo.mysql.com/apt/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} mysql-5.6
+    key: "{{ (ansible_distribution_release in ['stretch'])|ternary(None, 'mysql')}}"
   mysql_5_7:
-    source: deb http://repo.mysql.com/apt/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} mysql-5.7
-    key: "{{ (ansible_distribution_release in ['stretch'])|ternary('mysql_legacy', 'mysql')}}"
+    source: >-
+      {{ (ansible_distribution_release in ['stretch'])|ternary('deb [trusted=yes]', 'deb') }}
+      http://repo.mysql.com/apt/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} mysql-5.7
+    key: "{{ (ansible_distribution_release in ['stretch'])|ternary(None, 'mysql')}}"
   mysql_8_0:
-    source: deb http://repo.mysql.com/apt/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} mysql-8.0
-    key: "{{ (ansible_distribution_release in ['stretch'])|ternary('mysql_legacy', 'mysql')}}"
+    source: >-
+      {{ (ansible_distribution_release in ['stretch'])|ternary('deb [trusted=yes]', 'deb') }}
+      http://repo.mysql.com/apt/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} mysql-8.0
+    key: "{{ (ansible_distribution_release in ['stretch'])|ternary(None, 'mysql')}}"
   mariadb_10_1:
     source: deb http://ftp.osuosl.org/pub/mariadb/repo/10.1/debian {{ ansible_distribution_release }} main
     key: mariadb
@@ -317,9 +323,6 @@ manala_apt_keys_patterns:
   mysql:
     url: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
     id: 3A79BD29
-  mysql_legacy:
-    url: https://repo.mysql.com/RPM-GPG-KEY-mysql
-    id: 5072E1F5
   mariadb:
     url: https://raw.githubusercontent.com/MariaDB/mariadb.org-tools/master/release/create_package_tarballs/deb_files/MariaDB-C74CD1D8-public.asc
     id: C74CD1D8

--- a/tests/unit/plugins/lookup/test_apt_keys.py
+++ b/tests/unit/plugins/lookup/test_apt_keys.py
@@ -86,3 +86,16 @@ class Test(unittest.TestCase):
                 {'key': 'foo'}
             ]
         ]))
+
+    def test_no_key(self):
+        self.assertListEqual([
+        ], self.lookup.run([
+            [],
+            {
+                'foo': {'id': 'foo'},
+            },
+            [
+                {'key': None},
+                {'key': ''},
+            ]
+        ]))


### PR DESCRIPTION
Debian 9 (stretch) is no longer supported by MySQL and apt key expired on 2022-02-16.

This PR removes legacy MySQL key and trusts repository on stretch.

On existing servers you need to remove previous apt list (`rm /var/list/repo.mysql.com_apt_debian_dists_stretch_* `)

