### PR TITLE
[MySQL] Use pymysql over mysqldb lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ## Changed
 - [Apt] Trust MySQL repository on stretch
+### Added
+- [MySQL] Add `login_*` parameters in `users` and `databases` tasks.
 
 ## [1.0.9] - 2022-02-21
 ## Changed

--- a/molecule/mysql.5.7/converge.yml
+++ b/molecule/mysql.5.7/converge.yml
@@ -18,10 +18,11 @@
             manala_mysql_users:
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
             manala_mysql_databases:
               - name: foo
+                login_unix_socket: /var/run/mysqld/mysqld.sock
       always:
         - name: Goss
           command:
@@ -263,6 +264,7 @@
       vars:
         manala_mysql_users:
           - name: bar
+            login_unix_socket: /var/run/mysqld/mysqld.sock
             state: absent
     - name: Create users to absent/ignore later
       mysql_user:
@@ -280,25 +282,32 @@
               # Privileges and password
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               # States
               - name: state_present_implicit
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: state_present
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: present
               - name: state_absent
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_absent_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_ignored
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               - name: state_ignore_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
                   password: baz
-                  host: localhost
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
                   priv: "*.*:ALL,GRANT"
       always:
         - name: Goss
@@ -324,6 +333,7 @@
         manala_mysql_databases:
           - name: bar
             state: absent
+            login_unix_socket: /var/run/mysqld/mysqld.sock
     - name: Create databases to absent/ignore later
       mysql_db:
         name: "{{ item }}"
@@ -339,19 +349,26 @@
             manala_mysql_databases:
               # States
               - name: state_present_implicit
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: state_present
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: present
               - name: state_absent
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_absent_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_ignored
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               - name: state_ignore_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
       always:
         - name: Goss
           command:

--- a/molecule/mysql.8.0/converge.yml
+++ b/molecule/mysql.8.0/converge.yml
@@ -22,10 +22,11 @@
             manala_mysql_users:
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
             manala_mysql_databases:
               - name: foo
+                login_unix_socket: /var/run/mysqld/mysqld.sock
       always:
         - name: Goss
           command:
@@ -265,6 +266,7 @@
                 default-authentication-plugin: mysql_native_password
         manala_mysql_users:
           - name: bar
+            login_unix_socket: /var/run/mysqld/mysqld.sock
             state: absent
     - name: Create users to absent/ignore later
       mysql_user:
@@ -282,25 +284,31 @@
               # Privileges and password
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
               # States
               - name: state_present_implicit
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: state_present
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: present
               - name: state_absent
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_absent_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_ignored
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               - name: state_ignore_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
                   password: baz
-                  host: localhost
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
                   priv: "*.*:ALL,GRANT"
       always:
         - name: Goss
@@ -329,6 +337,7 @@
                 default-authentication-plugin: mysql_native_password
         manala_mysql_databases:
           - name: bar
+            login_unix_socket: /var/run/mysqld/mysqld.sock
             state: absent
     - name: Create databases to absent/ignore later
       mysql_db:
@@ -345,19 +354,26 @@
             manala_mysql_databases:
               # States
               - name: state_present_implicit
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: state_present
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: present
               - name: state_absent
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_absent_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_ignored
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               - name: state_ignore_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
       always:
         - name: Goss
           command:

--- a/molecule/mysql.mariadb.10.4/converge.yml
+++ b/molecule/mysql.mariadb.10.4/converge.yml
@@ -21,7 +21,7 @@
             manala_mysql_users:
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
               - name: bar
                 state: ignore
@@ -29,15 +29,18 @@
               -
                 - name: baz
                   password: baz
-                  host: localhost
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
                   priv: "*.*:ALL,GRANT"
             manala_mysql_databases:
               - name: foo
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: bar
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
       always:
         - name: Goss
           command:

--- a/molecule/mysql.mariadb.10.5/converge.yml
+++ b/molecule/mysql.mariadb.10.5/converge.yml
@@ -19,7 +19,7 @@
             manala_mysql_users:
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
               - name: bar
                 state: ignore
@@ -27,15 +27,18 @@
               -
                 - name: baz
                   password: baz
-                  host: localhost
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
                   priv: "*.*:ALL,GRANT"
             manala_mysql_databases:
               - name: foo
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: bar
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
       always:
         - name: Goss
           command:

--- a/molecule/mysql.mariadb.10.6/converge.yml
+++ b/molecule/mysql.mariadb.10.6/converge.yml
@@ -19,10 +19,11 @@
             manala_mysql_users:
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
             manala_mysql_databases:
               - name: foo
+                login_unix_socket: /var/run/mysqld/mysqld.sock
         - name: Goss
           command:
             cmd: goss --gossfile - validate
@@ -268,6 +269,7 @@
           - mariadb-client
         manala_mysql_users:
           - name: bar
+            login_unix_socket: /var/run/mysqld/mysqld.sock
     - name: Create users to absent/ignore later
       mysql_user:
         user: "{{ item }}"
@@ -284,25 +286,31 @@
               # Privileges and password
               - name: foo
                 password: foo
-                host: localhost
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 priv: "*.*:ALL,GRANT"
               # States
               - name: state_present_implicit
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: state_present
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: present
               - name: state_absent
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_absent_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_ignored
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               - name: state_ignore_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
                   password: baz
-                  host: localhost
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
                   priv: "*.*:ALL,GRANT"
       always:
         - name: Goss
@@ -328,6 +336,7 @@
           - mariadb-client
         manala_mysql_databases:
           - name: bar
+            login_unix_socket: /var/run/mysqld/mysqld.sock
             state: absent
     - name: Create databases to absent/ignore later
       mysql_db:
@@ -344,19 +353,26 @@
             manala_mysql_databases:
               # States
               - name: state_present_implicit
+                login_unix_socket: /var/run/mysqld/mysqld.sock
               - name: state_present
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: present
               - name: state_absent
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_absent_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: absent
               - name: state_ignored
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               - name: state_ignore_existing
+                login_unix_socket: /var/run/mysqld/mysqld.sock
                 state: ignore
               # Flatten
               -
                 - name: baz
+                  login_unix_socket: /var/run/mysqld/mysqld.sock
       always:
         - name: Goss
           command:

--- a/roles/mysql/tasks/databases.yml
+++ b/roles/mysql/tasks/databases.yml
@@ -5,6 +5,11 @@
     name: "{{ item.name }}"
     encoding: "{{ item.encoding|default('utf8') }}"
     collation: "{{ item.collation|default('utf8_general_ci') }}"
+    login_host: "{{ item.login_host|default(omit) }}"
+    login_port: "{{ item.login_port|default(omit) }}"
+    login_unix_socket: "{{ item.login_unix_socket|default(omit) }}"
+    login_user: "{{ item.login_user|default(omit) }}"
+    login_password: "{{ item.login_password|default(omit) }}"
     state: "{{ item.state|default(omit) }}"
   loop: "{{
     manala_mysql_databases

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -15,8 +15,8 @@
         or (manala_mysql_replications|length > 0)
       )|ternary(
         (ansible_python.version.major == 2)|ternary(
-          ['python-mysqldb'],
-          ['python3-mysqldb']
+          ['python-pymysql'],
+          ['python3-pymysql']
         ),
         []
       )

--- a/roles/mysql/tasks/users.yml
+++ b/roles/mysql/tasks/users.yml
@@ -8,6 +8,11 @@
     priv: "{{ item.priv|default(omit) }}"
     append_privs: "{{ item.append_privs|default(omit) }}"
     sql_log_bin: "{{ item.sql_log_bin|default(omit) }}"
+    login_host: "{{ item.login_host|default(omit) }}"
+    login_port: "{{ item.login_port|default(omit) }}"
+    login_unix_socket: "{{ item.login_unix_socket|default(omit) }}"
+    login_user: "{{ item.login_user|default(omit) }}"
+    login_password: "{{ item.login_password|default(omit) }}"
     state: "{{ item.state|default(omit) }}"
   loop: "{{
     manala_mysql_users


### PR DESCRIPTION
To avoid apt dependency on `mariadb-common` which can mess up Oracle MySQL config files.

On existing servers, the package `python3-mysqldb`/`python-mysqldb` need to be manually removed.