### PR TITLE
enh: Allow to enable services at boot

### DIFF
--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -12,6 +12,9 @@ manala_redis_install_packages_default: "{{
   + (manala_redis_sentinel)|ternary(['redis-sentinel'], [])
 }}"
 
+# Service
+manala_redis_service_enabled: true
+
 # Server
 manala_redis_server: true
 manala_redis_server_config_file: /etc/redis/redis.conf

--- a/roles/redis/tasks/services.yml
+++ b/roles/redis/tasks/services.yml
@@ -4,6 +4,7 @@
   service:
     name: "{{ item }}"
     state: started
+    enabled: "{{ manala_redis_service_enabled }}"
   loop: "{{
     []
     + (manala_redis_server)|ternary(['redis-server'], [])


### PR DESCRIPTION
Add default variable manala_redis_service_enabled (equals to true) in order to start service at boot.

Can be overwritten if not needed.