### PR TITLE
[Php] Fix extension handling when extension is already disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Php] Fix extension handling when extension is already disabled
 
 ## [2.0.1] - 2022-08-17
 ### Added

--- a/plugins/modules/php_extension.py
+++ b/plugins/modules/php_extension.py
@@ -80,15 +80,15 @@ def main():
 
 
 def run_phpquery(module, args):
-    return module.run_command('phpquery %s' % args, check_rc=True)
+    return module.run_command('phpquery %s' % args, check_rc=False)
 
 
 def run_phpenmod(module, args):
-    return module.run_command('phpenmod %s' % args)
+    return module.run_command('phpenmod %s' % args, check_rc=True)
 
 
 def run_phpdismod(module, args):
-    return module.run_command('phpdismod %s' % args)
+    return module.run_command('phpdismod %s' % args, check_rc=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
;TLDR `check_rc=True` arg in ansible module.run_command does *NOT* mean "dude, check the return code, and give it back to me" but "dude, check the return code by yourself and break my module if its != 0"
