### PR TITLE
[MySQL] Remove mariadb debian stretch tests

### DIFF
--- a/molecule/mysql.mariadb.10.3/converge.yml
+++ b/molecule/mysql.mariadb.10.3/converge.yml
@@ -7,7 +7,6 @@
 - name: Default
   tags: [default]
   hosts:
-    - debian.stretch
     - debian.buster
   tasks:
     - block:  # noqa unnamed-task

--- a/molecule/mysql.mariadb.10.3/prepare.yml
+++ b/molecule/mysql.mariadb.10.3/prepare.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts:
-    - debian.stretch
     - debian.buster
   tags: [always]
   tasks:

--- a/molecule/mysql.mariadb.10.4/converge.yml
+++ b/molecule/mysql.mariadb.10.4/converge.yml
@@ -7,7 +7,6 @@
 - name: Default
   tags: [default]
   hosts:
-    - debian.stretch
     - debian.buster
   tasks:
     - block:  # noqa unnamed-task

--- a/molecule/mysql.mariadb.10.4/prepare.yml
+++ b/molecule/mysql.mariadb.10.4/prepare.yml
@@ -1,7 +1,6 @@
 ---
 
 - hosts:
-    - debian.stretch
     - debian.buster
   tags: [always]
   tasks:

--- a/molecule/mysql.mariadb.10.5/converge.yml
+++ b/molecule/mysql.mariadb.10.5/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.stretch"
   tasks:
     - block:  # noqa unnamed-task
         - name: Role

--- a/molecule/mysql.mariadb.10.5/prepare.yml
+++ b/molecule/mysql.mariadb.10.5/prepare.yml
@@ -1,6 +1,8 @@
 ---
 
-- hosts: debian
+- hosts:
+    - debian
+    - "!debian.stretch"
   tags: [always]
   tasks:
     - name: Apt

--- a/molecule/mysql.mariadb.10.6/converge.yml
+++ b/molecule/mysql.mariadb.10.6/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.stretch"
   tasks:
     - block:  # noqa unnamed-task
         - name: Role
@@ -35,7 +37,9 @@
 
 - name: Default PyMySQL
   tags: [default, default.pymysql]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.stretch"
   tasks:
     - block:  # noqa unnamed-task
         - name: Role

--- a/molecule/mysql.mariadb.10.6/prepare.yml
+++ b/molecule/mysql.mariadb.10.6/prepare.yml
@@ -1,6 +1,8 @@
 ---
 
-- hosts: debian
+- hosts:
+    - debian
+    - "!debian.stretch"
   tags: [always]
   tasks:
     - name: Apt


### PR DESCRIPTION
Now that debian stretch packages have been removed from mariadb repositories