### PR TITLE
[Docker] Fix linting

### DIFF
--- a/roles/docker/tasks/update.yml
+++ b/roles/docker/tasks/update.yml
@@ -1,9 +1,8 @@
 ---
 
-- name: update > Pull
+- name: update > Pull  # noqa risky-shell-pipe
   ansible.builtin.shell: |
     docker images \
       | awk '/^REPOSITORY|\<none\>/ {next} {print $1":"$2}' \
       | xargs --max-args=1 --max-lines=1 --no-run-if-empty docker pull
-  tags:
-    - skip_ansible_lint
+  changed_when: false


### PR DESCRIPTION
For obscure reasons, docker role has kept the old-fashioned way of exclude linting rules using `skip_ansible_lint` tag