### PR TITLE
[Apt] Update grafana repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [Apt] Update grafana repository
 
 ## [3.1.0] - 2022-12-13
 ### Added

--- a/molecule/apt/goss/repositories.default.yml.j2
+++ b/molecule/apt/goss/repositories.default.yml.j2
@@ -20,14 +20,14 @@ file:
     contains:
       - "deb http://repo.percona.com/apt {{ ansible_distribution_release }} main"
   # Pattern syntax
-  /etc/apt/sources.list.d/packages_grafana_com_oss_deb.list:
+  /etc/apt/sources.list.d/apt_grafana_com.list:
     exists: true
     filetype: file
     owner: root
     group: root
     mode: "0644"
     contains:
-      - "deb https://packages.grafana.com/oss/deb stable main"
+      - "deb https://apt.grafana.com stable main"
   # Verbose syntax
   /etc/apt/sources.list.d/dl_yarnpkg_com_debian.list:
     exists: true

--- a/roles/apt/vars/main.yml
+++ b/roles/apt/vars/main.yml
@@ -171,7 +171,7 @@ manala_apt_repositories_patterns:
     source: deb https://releases.galeracluster.com/mysql-wsrep-8.0.26-26.8/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main
     key: galera
   grafana:
-    source: deb https://packages.grafana.com/oss/deb stable main
+    source: deb https://apt.grafana.com stable main
     key: grafana
   elasticsearch_5:
     source: deb https://artifacts.elastic.co/packages/5.x/apt stable main
@@ -391,7 +391,7 @@ manala_apt_keys_patterns:
     url: https://download.owncloud.org/download/repositories/production/Debian_{{ ansible_distribution_major_version }}.0/Release.key
     id: 479BC94B
   grafana:
-    url: https://packages.grafana.com/gpg.key
+    url: https://apt.grafana.com/gpg.key
     id: 24098CB6
   blackfire:
     url: https://packages.blackfire.io/gpg.key


### PR DESCRIPTION
Grafana have changed their apt repository around version `9.2` release date, from `https://packages.grafana.com/oss/deb` to `https://apt.grafana.com`. Key url also changed from `https://packages.grafana.com/gpg.key` to `https://apt.grafana.com/gpg.key`.

Look at:
- version `9.1` installation documentation: https://grafana.com/docs/grafana/v9.1/setup-grafana/installation/debian/#install-from-apt-repository
- version `9.2` installation documentation: https://grafana.com/docs/grafana/v9.2/setup-grafana/installation/debian/#install-from-apt-repository

I've double-checked, packages and key are strictly the same between both repos, only url changed.