### PR TITLE
[All] Update minimum version of ansible to 2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - [Telegraf] Update base config template
+- [All] Update minimum version of ansible to 2.11
 
 ## [3.1.1] - 2022-12-22
 ### Changed

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
 
-requires_ansible: '>=2.10'
+requires_ansible: '>=2.11'

--- a/roles/accounts/meta/main.yml
+++ b/roles/accounts/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle accounts users and groups
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/alternatives/meta/main.yml
+++ b/roles/alternatives/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle alternatives
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/ansible/meta/main.yml
+++ b/roles/ansible/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle ansible
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/ansible_galaxy/meta/main.yml
+++ b/roles/ansible_galaxy/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle ansible galaxy
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/apparmor/meta/main.yml
+++ b/roles/apparmor/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Install and configure AppArmor
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/apt/meta/main.yml
+++ b/roles/apt/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle apt
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/aptly/meta/main.yml
+++ b/roles/aptly/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle aptly
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/backup_manager/meta/main.yml
+++ b/roles/backup_manager/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle backup manager
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/bind/meta/main.yml
+++ b/roles/bind/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle bind
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/cloud_init/meta/main.yml
+++ b/roles/cloud_init/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Configure cloud-init
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/composer/meta/main.yml
+++ b/roles/composer/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle composer
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/cron/meta/main.yml
+++ b/roles/cron/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle cron
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/deploy/meta/main.yml
+++ b/roles/deploy/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle deploy
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/dhcp/meta/main.yml
+++ b/roles/dhcp/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle isc dhcp server
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/dnsmasq/meta/main.yml
+++ b/roles/dnsmasq/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle dnsmasq
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle Docker
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/elasticsearch/meta/main.yml
+++ b/roles/elasticsearch/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle elasticsearch
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/environment/meta/main.yml
+++ b/roles/environment/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle environment variables
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/fail2ban/meta/main.yml
+++ b/roles/fail2ban/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle fail2ban
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/files/meta/main.yml
+++ b/roles/files/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle files attributes
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/git/meta/main.yml
+++ b/roles/git/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle git
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/gitlab/meta/main.yml
+++ b/roles/gitlab/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle gitlab
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/glusterfs/meta/main.yml
+++ b/roles/glusterfs/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle glusterfs
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/gomplate/meta/main.yml
+++ b/roles/gomplate/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle gomplate
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/grafana/meta/main.yml
+++ b/roles/grafana/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle grafana
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle haproxy
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/influxdb/meta/main.yml
+++ b/roles/influxdb/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Install and configure InfluxDB
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/java/meta/main.yml
+++ b/roles/java/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle java
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/keepalived/meta/main.yml
+++ b/roles/keepalived/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle keepalived
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/kernel/meta/main.yml
+++ b/roles/kernel/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle kernel modules and parameters
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/locales/meta/main.yml
+++ b/roles/locales/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle locales
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/logrotate/meta/main.yml
+++ b/roles/logrotate/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle logrotate
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/make/meta/main.yml
+++ b/roles/make/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle make
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/maxscale/meta/main.yml
+++ b/roles/maxscale/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Installation and configuration of Maxscale (MySQL/MariaDB Proxy)
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/mongodb/meta/main.yml
+++ b/roles/mongodb/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle mongodb
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/motd/meta/main.yml
+++ b/roles/motd/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle motd
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/mount/meta/main.yml
+++ b/roles/mount/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle mount
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/mysql/meta/main.yml
+++ b/roles/mysql/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle mysql
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/network/meta/main.yml
+++ b/roles/network/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle network hosts, resolver and interfaces
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/nginx/meta/main.yml
+++ b/roles/nginx/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle nginx
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/ngrok/meta/main.yml
+++ b/roles/ngrok/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle ngrok
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/nodejs/meta/main.yml
+++ b/roles/nodejs/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle nodejs
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/npm/meta/main.yml
+++ b/roles/npm/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle npm
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/ntp/meta/main.yml
+++ b/roles/ntp/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle ntp
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/ohmyzsh/meta/main.yml
+++ b/roles/ohmyzsh/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle oh-my-zsh
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/pam_ssh_agent_auth/meta/main.yml
+++ b/roles/pam_ssh_agent_auth/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle pam ssh agent auth
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/php/meta/main.yml
+++ b/roles/php/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle php
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/postgresql/meta/main.yml
+++ b/roles/postgresql/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle postgresql
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/proftpd/meta/main.yml
+++ b/roles/proftpd/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle proftpd
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/prometheus/meta/main.yml
+++ b/roles/prometheus/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle prometheus
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/promtail/meta/main.yml
+++ b/roles/promtail/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle promtail
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/redis/meta/main.yml
+++ b/roles/redis/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle redis
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/rsyslog/meta/main.yml
+++ b/roles/rsyslog/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Install and configure rsyslog
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/sensu_go/meta/main.yml
+++ b/roles/sensu_go/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Install and configure sensu
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/shorewall/meta/main.yml
+++ b/roles/shorewall/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle shorewall
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/sqlite/meta/main.yml
+++ b/roles/sqlite/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle SQLite
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/ssh/meta/main.yml
+++ b/roles/ssh/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle ssh
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/sudo/meta/main.yml
+++ b/roles/sudo/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle sudo
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/supervisor/meta/main.yml
+++ b/roles/supervisor/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle supervisor
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/symfony_cli/meta/main.yml
+++ b/roles/symfony_cli/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle symfony cli
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/systemd/meta/main.yml
+++ b/roles/systemd/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Configure systemd services
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/telegraf/meta/main.yml
+++ b/roles/telegraf/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Setup and configure influxdata/telegraf
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/timezone/meta/main.yml
+++ b/roles/timezone/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle timezone
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/vault_cli/meta/main.yml
+++ b/roles/vault_cli/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle vault binary
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/vim/meta/main.yml
+++ b/roles/vim/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle vim
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/yarn/meta/main.yml
+++ b/roles/yarn/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle Yarn
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian

--- a/roles/zsh/meta/main.yml
+++ b/roles/zsh/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   company: Manala
   description: Handle zsh
   license: MIT
-  min_ansible_version: 2.10.0
+  min_ansible_version: 2.11.0
   issue_tracker_url: https://github.com/manala/ansible-roles/issues
   platforms:
     - name: Debian


### PR DESCRIPTION
Version 2.10 is no more supported.
See: https://ansible-lint.readthedocs.io/rules/meta-unsupported-ansible/