### PR TITLE
[NodeJS] Fix v16 npm version test

### DIFF
--- a/molecule/nodejs.18/goss/default.yml.j2
+++ b/molecule/nodejs.18/goss/default.yml.j2
@@ -12,4 +12,4 @@ command:
   npm --version:
     exit-status: 0
     stdout:
-      - "/^8.\\d+\\.\\d+$/"
+      - "/^9.\\d+\\.\\d+$/"


### PR DESCRIPTION
NodeJS 16 now comes with npm version 9