### PR TITLE
[CI] Update release process

### DIFF
--- a/.github/workflows/collection-release.yaml
+++ b/.github/workflows/collection-release.yaml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  collection-release:
+  collection-build:
     runs-on: ubuntu-22.04
     if: "contains(github.event.head_commit.message, 'Release')"
     steps:
@@ -21,6 +21,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Retrieve version from galaxy.yml
+        id: get_version
+        uses: CumulusDS/get-yaml-paths-action@v1.0.1
+        with:
+          file: ./galaxy.yml
+          version: version
+
       - name: Docker cache
         uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
@@ -34,16 +41,73 @@ jobs:
           cp .env.dist .env
 
       - name: Build Collection
+        id: build_collection
         run: make collection.build
 
+      - name: Create artifact from collection build
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./manala-roles-${{ steps.get_version.outputs.version }}.tar.gz
+          name: manala-roles-${{ steps.get_version.outputs.version }}
+          retention-days: 1
+
+      - name: Notify Slack of job status
+        uses: act10ns/slack@v2
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#collection_release'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()
+
+  collection-publish:
+    needs: collection-build
+    runs-on: ubuntu-22.04
+    if: "contains(github.event.head_commit.message, 'Release')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Retrieve version from galaxy.yml
+        id: get_version
+        uses: CumulusDS/get-yaml-paths-action@v1.0.1
+        with:
+          file: ./galaxy.yml
+          version: version
+
+      - name: Retrieve collection build from artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: manala-roles-${{ steps.get_version.outputs.version }}
+
       - name: Publish Collection
+        id: publish_collection
         run: make collection.publish
         env:
           COLLECTION_API_TOKEN: ${{ secrets.COLLECTION_API_TOKEN }}
 
+      - name: Notify Slack of job status
+        uses: act10ns/slack@v2
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#collection_release'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()
+
+  github-release:
+    needs: collection-build
+    runs-on: ubuntu-22.04
+    if: "contains(github.event.head_commit.message, 'Release')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Retrieve version from galaxy.yml
         id: get_version
-        uses: CumulusDS/get-yaml-paths-action@v0.1.0
+        uses: CumulusDS/get-yaml-paths-action@v1.0.1
         with:
           file: ./galaxy.yml
           version: version
@@ -55,30 +119,23 @@ jobs:
           path: ./CHANGELOG.md
           version: ${{ steps.get_version.outputs.version }}
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Retrieve collection build from artifact
+        uses: actions/download-artifact@v3
         with:
-          tag_name: ${{ steps.changelog.outputs.version }}
-          release_name: manala-roles ${{ steps.changelog.outputs.version }}
+          name: manala-roles-${{ steps.get_version.outputs.version }}
+
+      - name: Create Github Release
+        id: github_release
+        uses: ncipollo/release-action@v1
+        with:
+          name: manala-roles ${{ steps.get_version.outputs.version }}
+          tag: ${{ steps.get_version.outputs.version }}
           body: ${{ steps.changelog.outputs.changes }}
-          draft: false
-          prerelease: false
+          artifacts: ./manala-roles-${{ steps.get_version.outputs.version }}.tar.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          skipIfReleaseExists: true
 
-      - name: Upload Release Asset
-        id: upload_release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./manala-roles-${{ steps.changelog.outputs.version }}.tar.gz
-          asset_name: manala-roles-${{ steps.changelog.outputs.version }}.tar.gz
-          asset_content_type: application/zip
-
-      - name: Notify Slack of action status
+      - name: Notify Slack of job status
         uses: act10ns/slack@v2
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
We split into 3 jobs (`building collection`, `publishing on ansible-galaxy` and `publishing on github`) and update versions of actions/replace deprecated actions

Needed for several reasons:

- Ansible-galaxy is a mess right now and upload could easily fail. We need to separate the upload to galaxy and the upload to github, so if one fails the other can succeed. Then it's at least possible to install manually the collection by downloading it on Github. The 2 process of publishing can occured simultaneously.

- Some deprecation coming from old versions of `action/core`, which were use in several third-party actions in our workflow. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 