### PR TITLE
Update requirements strategy

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,8 +1,8 @@
 collections:
-  - ansible.posix
-  - community.general
-  - community.docker
-  - community.mysql
-  - community.postgresql
-  - community.mongodb
-  - gluster.gluster
+  - https://galaxy.ansible.com/download/ansible-posix-1.5.1.tar.gz
+  - https://galaxy.ansible.com/download/community-general-6.4.0.tar.gz
+  - https://galaxy.ansible.com/download/community-docker-3.4.2.tar.gz
+  - https://galaxy.ansible.com/download/community-mysql-3.6.0.tar.gz
+  - https://galaxy.ansible.com/download/community-postgresql-2.3.2.tar.gz
+  - https://galaxy.ansible.com/download/community-mongodb-1.3.0.tar.gz
+  - https://galaxy.ansible.com/download/gluster-gluster-1.0.2.tar.gz


### PR DESCRIPTION
After trying alternative strategies (such as git or github releases), using direct `.tar.gz` downloading from ansible galaxy servers offers the opportunity to bypass (unreliable) ansible galaxy api, at the cost of hard setting collection versions in the url.

🗒️ this only concerns tests/linting requirements ! Collection requirements themselves are defined in `galaxy.yml`file.