### PR TITLE
Fix ansible version requirement

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
 
-requires_ansible: '>=2.14'
+requires_ansible: '>=2.14.0'


### PR DESCRIPTION
According to `meta-runtime[invalid-version]` lint rule (see: https://ansible-lint.readthedocs.io/rules/meta-runtime/) `2.14` is no more a valid version, we must set `2.14.0`