### PR TITLE
Update noqa lint tags

### DIFF
--- a/molecule/accounts/converge.yml
+++ b/molecule/accounts/converge.yml
@@ -12,7 +12,7 @@
       ansible.builtin.group:
         name: "{{ item }}"
       loop: [group_state_absent_existing, group_state_ignore_existing]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.accounts
@@ -64,7 +64,7 @@
       ansible.builtin.user:
         name: "{{ item }}"
       loop: [user_state_absent_existing, user_state_ignore_existing]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.accounts
@@ -108,7 +108,7 @@
   tags: [users_authorized_keys]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.accounts
@@ -158,7 +158,7 @@
   tags: [users_keys]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.accounts
@@ -225,7 +225,7 @@
   tags: [users_gpg_keys]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.accounts

--- a/molecule/alternatives/converge.yml
+++ b/molecule/alternatives/converge.yml
@@ -19,7 +19,7 @@
         name: "{{ item[0] }}"
         path: "{{ item[1] }}"
       loop: [[editor, /bin/nano], [pico, /bin/nano], [pager, /bin/more]]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.alternatives

--- a/molecule/ansible/converge.yml
+++ b/molecule/ansible/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ansible
@@ -30,11 +30,11 @@
     tests_dir: /molecule/ansible/hosts
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             name: manala.roles.ansible
@@ -70,11 +70,11 @@
     tests_dir: /molecule/ansible/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             name: manala.roles.ansible
@@ -110,19 +110,19 @@
     tests_dir: /molecule/ansible/host_vars
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/foo, exclusive/bar, exclusive/baz, exclusive/qux,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.ansible
@@ -201,19 +201,19 @@
     tests_dir: /molecule/ansible/group_vars
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/foo, exclusive/bar, exclusive/baz, exclusive/qux,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.ansible

--- a/molecule/ansible_galaxy/converge.yml
+++ b/molecule/ansible_galaxy/converge.yml
@@ -8,7 +8,7 @@
   tags: [roles]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ansible_galaxy

--- a/molecule/apparmor/converge.yml
+++ b/molecule/apparmor/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.apparmor
@@ -30,19 +30,19 @@
     tests_dir: /molecule/apparmor/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/apt/converge.yml
+++ b/molecule/apt/converge.yml
@@ -11,19 +11,19 @@
     tests_dir: /molecule/apt/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.apt
@@ -102,11 +102,11 @@
     tests_dir: /molecule/apt/sources_list
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             name: manala.roles.apt
@@ -142,19 +142,19 @@
     tests_dir: /molecule/apt/preferences
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.apt
@@ -272,7 +272,7 @@
   tags: [keys]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.apt
@@ -326,7 +326,7 @@
       loop:
         - deb https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main
         - deb https://deb.nodesource.com/node_15.x {{ ansible_distribution_release }} main
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully, because of "keys" tasks dependency
@@ -384,7 +384,7 @@
         - deb https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main
         - deb https://deb.nodesource.com/node_14.x {{ ansible_distribution_release }} main
         - deb https://deb.nodesource.com/node_15.x {{ ansible_distribution_release }} main
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully, because of "keys" tasks dependency
@@ -431,7 +431,7 @@
             'aarch64': 'https://snapshot.debian.org/archive/debian/20140820T100258Z/pool/main/p/pscan/pscan_1.2-9_arm64.deb',
             'armv7l': 'https://snapshot.debian.org/archive/debian/20111201T234959Z/pool/main/p/pscan/pscan_1.2-9_armhf.deb',
           }[ansible_architecture] }}
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.apt
@@ -485,7 +485,7 @@
         name: "{{ item }}"
         selection: hold
       loop: [dpkg, tar]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.apt
@@ -521,7 +521,7 @@
         name: "{{ item }}"
         selection: hold
       loop: [python3, tar]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.apt
@@ -549,7 +549,7 @@
   tags: [update]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.apt

--- a/molecule/aptly/converge.yml
+++ b/molecule/aptly/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.aptly
@@ -30,11 +30,11 @@
     tests_dir: /molecule/aptly/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -80,7 +80,7 @@
   vars:
     tests_dir: /molecule/aptly/repositories
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.aptly

--- a/molecule/backup_manager/converge.yml
+++ b/molecule/backup_manager/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.backup_manager
@@ -30,19 +30,19 @@
     tests_dir: /molecule/backup_manager/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.backup_manager

--- a/molecule/bind/converge.yml
+++ b/molecule/bind/converge.yml
@@ -11,11 +11,11 @@
     tests_dir: /molecule/bind/default
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.bind
@@ -39,11 +39,11 @@
     tests_file: /molecule/bind/options
   tasks:
     - name: Clean tests file
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_file }}"
         state: "{{ item }}"
       loop: [absent, touch]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.bind
@@ -70,16 +70,16 @@
     tests_dir: /molecule/bind/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [state_absent_existing]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.bind
@@ -115,16 +115,16 @@
     tests_dir: /molecule/bind/zones
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [db.state_absent_existing, db.dynamic_existing]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.bind
@@ -165,7 +165,7 @@
   tags: [zones_records]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.bind

--- a/molecule/cloud_init/converge.yml
+++ b/molecule/cloud_init/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.cloud_init
@@ -30,19 +30,19 @@
     tests_dir: /molecule/cloud_init/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.cloud_init

--- a/molecule/composer/converge.yml
+++ b/molecule/composer/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.composer
@@ -30,11 +30,11 @@
     tests_dir: /molecule/composer/version
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Fixed
           ansible.builtin.import_role:
             name: manala.roles.composer
@@ -105,7 +105,7 @@
   tags: [users_auth]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.composer

--- a/molecule/cron/converge.yml
+++ b/molecule/cron/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.cron
@@ -30,19 +30,19 @@
     tests_dir: /molecule/cron/files
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.cron

--- a/molecule/deploy/converge.yml
+++ b/molecule/deploy/converge.yml
@@ -11,11 +11,11 @@
     tests_dir: /molecule/deploy/default
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -41,11 +41,11 @@
     tests_dir: /molecule/deploy/strategy
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Synchronize
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -83,27 +83,27 @@
     tests_dir: /molecule/deploy/shared
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: Directories
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/app/{{ item }}"
         state: directory
       loop: [shared, shared/dir, shared/dir/dir]
     - name: Files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/app/{{ item }}"
         state: touch
       loop: [shared/file_shared_existing, shared/dir/file_shared_existing, shared/dir/dir/file_shared_existing]
     - name: Links
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/app/{{ item }}_link"
         src: "{{ tests_dir }}/app/{{ item }}"
         state: link
       loop: [shared/file_shared_existing, shared/dir/file_shared_existing, shared/dir/dir/file_shared_existing]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -143,20 +143,20 @@
     tests_dir: /molecule/deploy/copied
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: Directory
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/app/releases/20170520092302/vendor"
         state: directory
     - name: Link
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/app/current"
         src: "{{ tests_dir }}/app/releases/20170520092302"
         state: link
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -184,11 +184,11 @@
     tests_dir: /molecule/deploy/writable
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -220,11 +220,11 @@
     tests_dir: /molecule/deploy/tasks
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Raw
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -252,11 +252,11 @@
     tests_dir: /molecule/deploy/removed
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -285,16 +285,16 @@
     tests_dir: /molecule/deploy/clean
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: Directories
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/app/releases/{{ item }}"
         state: directory
       loop: [20170520092302, 20170520092413, 20170520092714, 20170520092738, 20170520093012, 20170520093234]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.deploy
@@ -321,11 +321,11 @@
     tests_dir: /molecule/deploy/post_tasks
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Raw
           ansible.builtin.import_role:
             name: manala.roles.deploy

--- a/molecule/deploy/fixtures/strategy.yml
+++ b/molecule/deploy/fixtures/strategy.yml
@@ -1,6 +1,6 @@
 ---
 
-- block:  # noqa name[missing]
+- block:  # noqa: name[missing]
     - name: strategy > Create release dir
       ansible.builtin.file:
         path: "{{ deploy_helper.new_release_path }}/"

--- a/molecule/dhcp/converge.yml
+++ b/molecule/dhcp/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.dhcp

--- a/molecule/dnsmasq/converge.yml
+++ b/molecule/dnsmasq/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.dnsmasq
@@ -30,19 +30,19 @@
     tests_dir: /molecule/dnsmasq/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/docker/converge.yml
+++ b/molecule/docker/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.docker
@@ -33,11 +33,11 @@
     tests_dir: /molecule/docker/config_daemon
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -90,11 +90,11 @@
     tests_dir: /molecule/docker/applications
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.docker
@@ -125,7 +125,7 @@
   tags: [containers]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.docker
@@ -157,7 +157,7 @@
   tags: [update]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.docker

--- a/molecule/elasticsearch.5/converge.yml
+++ b/molecule/elasticsearch.5/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.elasticsearch

--- a/molecule/elasticsearch.6/converge.yml
+++ b/molecule/elasticsearch.6/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.elasticsearch

--- a/molecule/elasticsearch.7/converge.yml
+++ b/molecule/elasticsearch.7/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.elasticsearch
@@ -44,11 +44,11 @@
     tests_dir: /molecule/elasticsearch/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -111,11 +111,11 @@
     tests_dir: /molecule/elasticsearch/environment
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/environment/converge.yml
+++ b/molecule/environment/converge.yml
@@ -11,31 +11,31 @@
     tests_dir: /molecule/environment/default
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: Pam file
-      ansible.builtin.copy:  # noqa risky-file-permissions
+      ansible.builtin.copy:  # noqa: risky-file-permissions
         dest: /etc/environment
         content: |
           _FOO="bar"
           _BAR="123"
     - name: Zsh directory
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: /etc/zsh
         state: directory
     - name: Zsh file
-      ansible.builtin.copy:  # noqa risky-file-permissions
+      ansible.builtin.copy:  # noqa: risky-file-permissions
         dest: /etc/zsh/zshenv
         content: |
           # /etc/zsh/zshenv
     - name: File
-      ansible.builtin.copy:  # noqa risky-file-permissions
+      ansible.builtin.copy:  # noqa: risky-file-permissions
         dest: "{{ tests_dir }}/file"
         content: |
           # {{ tests_dir }}/file
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.environment

--- a/molecule/fail2ban/converge.yml
+++ b/molecule/fail2ban/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.fail2ban
@@ -36,11 +36,11 @@
     tests_dir: /molecule/fail2ban/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/files/converge.yml
+++ b/molecule/files/converge.yml
@@ -12,15 +12,15 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: Role
@@ -65,15 +65,15 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: Role
@@ -83,7 +83,7 @@
                 manala_files_attributes:
                   - path: "{{ tests_dir }}/default/default"
         # Parents
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Role
               ansible.builtin.import_role:
                 name: manala.roles.files
@@ -97,12 +97,12 @@
                   - path: "{{ tests_dir }}/parents_defaults/file"
                   - path: "{{ tests_dir }}/parents_unexisting/file"
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # File already exists as empty directory
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directories
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: directory
               loop:
@@ -118,12 +118,12 @@
                     force: true
                   - path: "{{ tests_dir }}/file_directory_empty/file"
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # File already exists as full directory
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directories
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: directory
               loop:
@@ -131,7 +131,7 @@
                 - file_directory_full/file_force
                 - file_directory_full/file
             - name: Files
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: touch
               loop:
@@ -146,20 +146,20 @@
                     force: true
                   - path: "{{ tests_dir }}/file_directory_full/file"
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # File already exists as link to file
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/file_link_file"
                 state: directory
             - name: File
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/file_link_file/link_file"
                 state: touch
             - name: Links
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 src: "{{ tests_dir }}/file_link_file/link_file"
                 state: link
@@ -175,16 +175,16 @@
                     force: true
                   - path: "{{ tests_dir }}/file_link_file/file"
         # File already exists as link to directory
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directories
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: directory
               loop:
                 - file_link_directory
                 - file_link_directory/link_file
             - name: Links
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 src: "{{ tests_dir }}/file_link_directory/link_file"
                 state: link
@@ -200,7 +200,7 @@
                     force: true
                   - path: "{{ tests_dir }}/file_link_directory/file"
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
       always:
         - name: Goss
@@ -221,23 +221,23 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: File
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/file"
         state: touch
     - name: Directory
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/directory"
         state: directory
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: Role
@@ -264,7 +264,7 @@
                       src: "{{ tests_dir }}/default/link_directory"
                       state: link
         # Parents
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Role
               ansible.builtin.import_role:
                 name: manala.roles.files
@@ -284,16 +284,16 @@
                     src: "{{ tests_dir }}/file"
                     state: link_directory
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # Wrong
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/wrong"
                 state: directory
             - name: Link
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/wrong/link"
                 src: "{{ tests_dir }}/file"
                 state: link
@@ -306,13 +306,13 @@
                     src: "{{ tests_dir }}/directory"
                     state: link
         # Link already exists as file
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/link_file"
                 state: directory
             - name: Files
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: touch
               loop:
@@ -331,12 +331,12 @@
                     src: "{{ tests_dir }}/file"
                     state: link
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # Link already exists as empty directory
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directories
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: directory
               loop:
@@ -356,12 +356,12 @@
                     src: "{{ tests_dir }}/file"
                     state: link
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # Link already exists as full directory
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directories
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: directory
               loop:
@@ -369,7 +369,7 @@
                 - link_directory_full/link_force
                 - link_directory_full/link
             - name: Files
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: touch
               loop:
@@ -388,7 +388,7 @@
                     src: "{{ tests_dir }}/file"
                     state: link
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
       always:
         - name: Goss
@@ -409,15 +409,15 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: File
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: Role
@@ -428,13 +428,13 @@
                   - path: "{{ tests_dir }}/default/default"
                     state: directory
         # Directory already exists as file
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/directory_file"
                 state: directory
             - name: Files
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: touch
               loop:
@@ -451,20 +451,20 @@
                   - path: "{{ tests_dir }}/directory_file/directory"
                     state: directory
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # Directory already exists as link to file
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/directory_link_file"
                 state: directory
             - name: File
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/directory_link_file/link_file"
                 state: touch
             - name: Link
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 src: "{{ tests_dir }}/directory_link_file/link_file"
                 state: link
@@ -482,19 +482,19 @@
                   - path: /"tmp/directory/directory_link_file/directory"
                     state: directory
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
         # Directory already exists as link to directory
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directories
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 state: directory
               loop:
                 - directory_link_directory
                 - directory_link_directory/link_directory
             - name: Links
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/{{ item }}"
                 src: "{{ tests_dir }}/directory_link_directory/link_directory"
                 state: link
@@ -530,21 +530,21 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
         - name: Directory
-          ansible.builtin.file:  # noqa risky-file-permissions
+          ansible.builtin.file:  # noqa: risky-file-permissions
             path: "{{ tests_dir }}/default"
             state: directory
         - name: File
-          ansible.builtin.file:  # noqa risky-file-permissions
+          ansible.builtin.file:  # noqa: risky-file-permissions
             path: "{{ tests_dir }}/default/absent"
             state: touch
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Role
               ansible.builtin.import_role:
                 name: manala.roles.files
@@ -580,15 +580,15 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: Role
@@ -623,19 +623,19 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: File
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default/absent"
                 state: touch
             - name: Role
@@ -657,7 +657,7 @@
                     - path: "{{ tests_dir }}/default/ignore"
                       state: ignore
         # Parents
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Roles
               ansible.builtin.import_role:
                 name: manala.roles.files
@@ -677,7 +677,7 @@
                     content: |
                       Content defaults parents
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
       always:
         - name: Goss
@@ -698,19 +698,19 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: File
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default/absent"
                 state: touch
             - name: Role
@@ -730,7 +730,7 @@
                     - path: "{{ tests_dir }}/default/ignore"
                       state: ignore
         # Parents
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Role
               ansible.builtin.import_role:
                 name: manala.roles.files
@@ -747,7 +747,7 @@
                   - path: "{{ tests_dir }}/parents_unexisting/template"
                     template: fixtures/template.j2
           rescue:
-            - ansible.builtin.debug:  # noqa name[missing]
+            - ansible.builtin.debug:  # noqa: name[missing]
                 msg: A planned error has been caught...
       always:
         - name: Goss
@@ -768,15 +768,15 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: Role
@@ -817,15 +817,15 @@
   gather_facts: false
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         # Default
-        - block:  # noqa name[missing]
+        - block:  # noqa: name[missing]
             - name: Directory
-              ansible.builtin.file:  # noqa risky-file-permissions
+              ansible.builtin.file:  # noqa: risky-file-permissions
                 path: "{{ tests_dir }}/default"
                 state: directory
             - name: Role

--- a/molecule/git/converge.yml
+++ b/molecule/git/converge.yml
@@ -11,12 +11,12 @@
     tests_dir: /molecule/git/default
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
         mode: "0777"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.git
@@ -45,11 +45,11 @@
     tests_dir: /molecule/git/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             name: manala.roles.git

--- a/molecule/gitlab/converge.yml
+++ b/molecule/gitlab/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.gitlab
@@ -30,19 +30,19 @@
     tests_dir: /molecule/gitlab/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/glusterfs.6.1/converge.yml
+++ b/molecule/glusterfs.6.1/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.glusterfs
@@ -32,11 +32,11 @@
     tests_dir: /molecule/glusterfs/volumes
   tasks:
     - name: Directories
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: directory
       loop: [absent, present, test_1, test_2, test_3]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - 1
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/gomplate/converge.yml
+++ b/molecule/gomplate/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.gomplate
@@ -30,11 +30,11 @@
     tests_dir: /molecule/gomplate/version
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Fixed
           ansible.builtin.import_role:
             name: manala.roles.gomplate

--- a/molecule/grafana/converge.yml
+++ b/molecule/grafana/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.grafana
@@ -30,11 +30,11 @@
     tests_dir: /molecule/grafana/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             name: manala.roles.grafana
@@ -67,7 +67,7 @@
   tags: [datasources]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.grafana
@@ -98,7 +98,7 @@
   tags: [dashboards]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.grafana

--- a/molecule/haproxy/converge.yml
+++ b/molecule/haproxy/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.haproxy
@@ -30,19 +30,19 @@
     tests_dir: /molecule/haproxy/errorfiles
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.haproxy
@@ -121,11 +121,11 @@
     tests_dir: /molecule/haproxy/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -161,19 +161,19 @@
     tests_dir: /molecule/haproxy/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.haproxy
@@ -252,11 +252,11 @@
     tests_dir: /molecule/haproxy/environment
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/influxdb/converge.yml
+++ b/molecule/influxdb/converge.yml
@@ -11,11 +11,11 @@
     tests_dir: /molecule/influxdb/default
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.influxdb
@@ -52,11 +52,11 @@
     tests_dir: /molecule/influxdb/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/java/converge.yml
+++ b/molecule/java/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.java

--- a/molecule/keepalived/converge.yml
+++ b/molecule/keepalived/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.keepalived
@@ -35,11 +35,11 @@
     tests_dir: /molecule/keepalived/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -75,11 +75,11 @@
     tests_dir: /molecule/keepalived/environment
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/kernel/converge.yml
+++ b/molecule/kernel/converge.yml
@@ -8,7 +8,7 @@
   tags: [parameters]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.kernel

--- a/molecule/locales/converge.yml
+++ b/molecule/locales/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.locales
@@ -27,7 +27,7 @@
   tags: [codes, codes.codes]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - 1
           ansible.builtin.import_role:
             name: manala.roles.locales
@@ -79,7 +79,7 @@
   tags: [codes, codes.default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.locales

--- a/molecule/logrotate/converge.yml
+++ b/molecule/logrotate/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.logrotate
@@ -30,19 +30,19 @@
     tests_dir: /molecule/logrotate/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.logrotate

--- a/molecule/make/converge.yml
+++ b/molecule/make/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.make

--- a/molecule/maxscale.2.3/converge.yml
+++ b/molecule/maxscale.2.3/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.maxscale

--- a/molecule/maxscale.2.4/converge.yml
+++ b/molecule/maxscale.2.4/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.maxscale

--- a/molecule/maxscale.2.5/converge.yml
+++ b/molecule/maxscale.2.5/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.maxscale
@@ -32,11 +32,11 @@
     tests_dir: /molecule/maxscale/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -73,19 +73,19 @@
     tests_dir: /molecule/maxscale/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.maxscale
@@ -165,11 +165,11 @@
     tests_dir: /molecule/maxscale/users
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Array
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/maxscale.6.1/converge.yml
+++ b/molecule/maxscale.6.1/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.maxscale
@@ -30,11 +30,11 @@
     tests_dir: /molecule/maxscale/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -70,19 +70,19 @@
     tests_dir: /molecule/maxscale/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.maxscale
@@ -161,11 +161,11 @@
     tests_dir: /molecule/maxscale/users
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Array
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/motd/converge.yml
+++ b/molecule/motd/converge.yml
@@ -11,19 +11,19 @@
     tests_dir: /molecule/motd/scripts
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.motd

--- a/molecule/mount/converge.yml
+++ b/molecule/mount/converge.yml
@@ -11,14 +11,14 @@
     tests_dir: /molecule/mount/points
   tasks:
     - name: Directory
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/directory"
         state: directory
     - name: File
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/directory/file"
         state: touch
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mount

--- a/molecule/mysql.5.7/converge.yml
+++ b/molecule/mysql.5.7/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -43,7 +43,7 @@
           - mysql-server
           - mysql-client
         state: absent
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -68,11 +68,11 @@
     tests_dir: /molecule/mysql/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -120,19 +120,19 @@
     tests_dir: /molecule/mysql/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -220,11 +220,11 @@
     tests_dir: /molecule/mysql/data
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -270,7 +270,7 @@
       loop: [
         state_absent_existing, state_ignore_existing,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -330,7 +330,7 @@
       loop: [
         state_absent_existing, state_ignore_existing,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql

--- a/molecule/mysql.8.0/converge.yml
+++ b/molecule/mysql.8.0/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -47,7 +47,7 @@
           - mysql-server
           - mysql-client
         state: absent
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -71,11 +71,11 @@
     tests_dir: /molecule/mysql/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -122,19 +122,19 @@
     tests_dir: /molecule/mysql/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -221,11 +221,11 @@
     tests_dir: /molecule/mysql/data
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -278,7 +278,7 @@
       loop: [
         state_absent_existing, state_ignore_existing,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -343,7 +343,7 @@
       loop: [
         state_absent_existing, state_ignore_existing,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql

--- a/molecule/mysql.galera.4.10.mysql_wsrep.8.0.26/converge.yml
+++ b/molecule/mysql.galera.4.10.mysql_wsrep.8.0.26/converge.yml
@@ -10,7 +10,7 @@
     - debian.buster
     - debian.bullseye
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql

--- a/molecule/mysql.mariadb.10.3/converge.yml
+++ b/molecule/mysql.mariadb.10.3/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql

--- a/molecule/mysql.mariadb.10.4/converge.yml
+++ b/molecule/mysql.mariadb.10.4/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql

--- a/molecule/mysql.mariadb.10.5/converge.yml
+++ b/molecule/mysql.mariadb.10.5/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql

--- a/molecule/mysql.mariadb.10.6/converge.yml
+++ b/molecule/mysql.mariadb.10.6/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -37,7 +37,7 @@
   tags: [default, default.pymysql]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -84,7 +84,7 @@
           - mariadb-server
           - mariadb-client
         state: absent
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -110,11 +110,11 @@
     tests_dir: /molecule/mysql/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -164,19 +164,19 @@
     tests_dir: /molecule/mysql/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -266,11 +266,11 @@
     tests_dir: /molecule/mysql/data
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -321,7 +321,7 @@
       loop: [
         state_absent_existing, state_ignore_existing,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql
@@ -383,7 +383,7 @@
       loop: [
         state_absent_existing, state_ignore_existing,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.mysql

--- a/molecule/network/converge.yml
+++ b/molecule/network/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.network
@@ -30,17 +30,17 @@
     tests_dir: /molecule/network/hosts
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: File
-      ansible.builtin.copy:  # noqa risky-file-permissions
+      ansible.builtin.copy:  # noqa: risky-file-permissions
         dest: "{{ tests_dir }}/dict"
         content: |
           1.1.1.111 bar.com
           1.1.1.222 bar.com
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             name: manala.roles.network
@@ -68,11 +68,11 @@
     tests_dir: /molecule/network/resolver_config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             name: manala.roles.network
@@ -108,11 +108,11 @@
     tests_dir: /molecule/network/interfaces_config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             name: manala.roles.network
@@ -148,19 +148,19 @@
     tests_dir: /molecule/network/interfaces_configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.network
@@ -239,18 +239,18 @@
     tests_dir: /molecule/network/routing_tables
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: File
-      ansible.builtin.copy:  # noqa risky-file-permissions no-tabs
+      ansible.builtin.copy:  # noqa: risky-file-permissions no-tabs
         dest: "{{ tests_dir }}/dict"
         content: |
           255	local
           254	main
           253	foo
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             name: manala.roles.network

--- a/molecule/nginx/converge.yml
+++ b/molecule/nginx/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nginx
@@ -30,11 +30,11 @@
     tests_dir: /molecule/nginx/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -86,19 +86,19 @@
     tests_dir: /molecule/nginx/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.nginx

--- a/molecule/ngrok/converge.yml
+++ b/molecule/ngrok/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ngrok
@@ -30,11 +30,11 @@
     tests_dir: /molecule/ngrok/version
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Fixed
           ansible.builtin.import_role:
             name: manala.roles.ngrok
@@ -60,19 +60,19 @@
     tests_dir: /molecule/ngrok/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.ngrok

--- a/molecule/nodejs.10/converge.yml
+++ b/molecule/nodejs.10/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.12/converge.yml
+++ b/molecule/nodejs.12/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.14/converge.yml
+++ b/molecule/nodejs.14/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.16/converge.yml
+++ b/molecule/nodejs.16/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.18/converge.yml
+++ b/molecule/nodejs.18/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.4/converge.yml
+++ b/molecule/nodejs.4/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.6/converge.yml
+++ b/molecule/nodejs.6/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.7/converge.yml
+++ b/molecule/nodejs.7/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.8/converge.yml
+++ b/molecule/nodejs.8/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/nodejs.9/converge.yml
+++ b/molecule/nodejs.9/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.nodejs

--- a/molecule/npm/converge.yml
+++ b/molecule/npm/converge.yml
@@ -8,7 +8,7 @@
   tags: [packages]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.npm

--- a/molecule/ntp/converge.yml
+++ b/molecule/ntp/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ntp

--- a/molecule/ohmyzsh/converge.yml
+++ b/molecule/ohmyzsh/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ohmyzsh
@@ -30,19 +30,19 @@
     tests_dir: /molecule/ohmyzsh/custom_themes
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.ohmyzsh
@@ -121,7 +121,7 @@
     tests_dir: /molecule/ohmyzsh/users
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{
@@ -132,7 +132,7 @@
       ansible.builtin.user:
         name: "{{ item }}"
       loop: [user_dict, user_content, user_template, user_flatten, user_state_present_implicit, user_state_present, user_state_absent, user_state_ignore]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ohmyzsh

--- a/molecule/pam_ssh_agent_auth/converge.yml
+++ b/molecule/pam_ssh_agent_auth/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.pam_ssh_agent_auth

--- a/molecule/php.5.6/converge.yml
+++ b/molecule/php.5.6/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -90,7 +90,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -125,7 +125,7 @@
     tests_dir: /molecule/php/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: |
@@ -134,7 +134,7 @@
           'default/fpm/conf.d', 'defaults/fpm/conf.d', 'exclusive/fpm/conf.d',
         ] | product(['absent', 'directory']) }}
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
@@ -145,7 +145,7 @@
         exclusive/fpm/conf.d/existing, exclusive/fpm/conf.d/existing_present, exclusive/fpm/conf.d/existing_ignore,
         exclusive/fpm/conf.d/existing_fpm, exclusive/fpm/conf.d/existing_present_fpm, exclusive/fpm/conf.d/existing_ignore_fpm,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -257,19 +257,19 @@
     tests_dir: /molecule/php/fpm_pools
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.7.0/converge.yml
+++ b/molecule/php.7.0/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.7.1/converge.yml
+++ b/molecule/php.7.1/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.7.2/converge.yml
+++ b/molecule/php.7.2/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.7.3/converge.yml
+++ b/molecule/php.7.3/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.7.4/converge.yml
+++ b/molecule/php.7.4/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -90,7 +90,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -125,7 +125,7 @@
     tests_dir: /molecule/php/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: |
@@ -134,7 +134,7 @@
           'default/fpm/conf.d', 'defaults/fpm/conf.d', 'exclusive/fpm/conf.d',
         ] | product(['absent', 'directory']) }}
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
@@ -145,7 +145,7 @@
         exclusive/fpm/conf.d/existing, exclusive/fpm/conf.d/existing_present, exclusive/fpm/conf.d/existing_ignore,
         exclusive/fpm/conf.d/existing_fpm, exclusive/fpm/conf.d/existing_present_fpm, exclusive/fpm/conf.d/existing_ignore_fpm,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -257,19 +257,19 @@
     tests_dir: /molecule/php/fpm_pools
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.8.0/converge.yml
+++ b/molecule/php.8.0/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.8.1/converge.yml
+++ b/molecule/php.8.1/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/php.8.2/converge.yml
+++ b/molecule/php.8.2/converge.yml
@@ -17,7 +17,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -90,7 +90,7 @@
         install_recommends: false
         update_cache: true
         cache_valid_time: 3600
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -125,7 +125,7 @@
     tests_dir: /molecule/php/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: |
@@ -134,7 +134,7 @@
           'default/fpm/conf.d', 'defaults/fpm/conf.d', 'exclusive/fpm/conf.d'
         ] | product(['absent', 'directory']) }}
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
@@ -145,7 +145,7 @@
         exclusive/fpm/conf.d/existing, exclusive/fpm/conf.d/existing_present, exclusive/fpm/conf.d/existing_ignore,
         exclusive/fpm/conf.d/existing_fpm, exclusive/fpm/conf.d/existing_present_fpm, exclusive/fpm/conf.d/existing_ignore_fpm,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.php
@@ -257,19 +257,19 @@
     tests_dir: /molecule/php/fpm_pools
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.php

--- a/molecule/postgresql.9.4/converge.yml
+++ b/molecule/postgresql.9.4/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.postgresql
@@ -48,11 +48,11 @@
     tests_dir: /molecule/postgresql/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Content
           ansible.builtin.import_role:
             name: manala.roles.postgresql

--- a/molecule/proftpd/converge.yml
+++ b/molecule/proftpd/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.proftpd
@@ -30,19 +30,19 @@
     tests_dir: /molecule/proftpd/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.proftpd
@@ -135,11 +135,11 @@
     tests_dir: /molecule/proftpd/users
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.proftpd

--- a/molecule/prometheus/converge.yml
+++ b/molecule/prometheus/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.prometheus

--- a/molecule/promtail/converge.yml
+++ b/molecule/promtail/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.promtail

--- a/molecule/redis.5.0/converge.yml
+++ b/molecule/redis.5.0/converge.yml
@@ -9,7 +9,7 @@
   hosts:
     - debian.buster
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.redis

--- a/molecule/redis.6.0/converge.yml
+++ b/molecule/redis.6.0/converge.yml
@@ -10,7 +10,7 @@
     - debian.buster
     - debian.bullseye
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.redis
@@ -36,15 +36,15 @@
     tests_dir: /molecule/redis/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
     - name: Create sentinel_config_dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/dict-sentinel"
         state: touch
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/rsyslog/converge.yml
+++ b/molecule/rsyslog/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.rsyslog
@@ -30,11 +30,11 @@
     tests_dir: /molecule/rsyslog/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             name: manala.roles.rsyslog
@@ -80,19 +80,19 @@
     tests_dir: /molecule/rsyslog/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.rsyslog

--- a/molecule/sensu_go/converge.yml
+++ b/molecule/sensu_go/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.sensu_go
@@ -32,11 +32,11 @@
     tests_dir: /molecule/sensu_go/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             name: manala.roles.sensu_go

--- a/molecule/shorewall/converge.yml
+++ b/molecule/shorewall/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.shorewall
@@ -45,19 +45,19 @@
     tests_dir: /molecule/shorewall/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -155,11 +155,11 @@
     tests_dir: /molecule/shorewall/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/sqlite/converge.yml
+++ b/molecule/sqlite/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.sqlite

--- a/molecule/ssh/converge.yml
+++ b/molecule/ssh/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ssh
@@ -35,7 +35,7 @@
           - openssh-server
           - openssh-client
         state: absent
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.ssh
@@ -59,11 +59,11 @@
     tests_dir: /molecule/ssh/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks

--- a/molecule/sudo/converge.yml
+++ b/molecule/sudo/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.sudo
@@ -30,19 +30,19 @@
     tests_dir: /molecule/sudo/sudoers
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.sudo

--- a/molecule/supervisor/converge.yml
+++ b/molecule/supervisor/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.supervisor
@@ -30,11 +30,11 @@
     tests_dir: /molecule/supervisor/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -84,19 +84,19 @@
     tests_dir: /molecule/supervisor/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.supervisor

--- a/molecule/symfony_cli/converge.yml
+++ b/molecule/symfony_cli/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.symfony_cli
@@ -30,11 +30,11 @@
     tests_dir: /molecule/symfony_cli/version
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Fixed
           ansible.builtin.import_role:
             name: manala.roles.symfony_cli

--- a/molecule/systemd/converge.yml
+++ b/molecule/systemd/converge.yml
@@ -11,19 +11,19 @@
     tests_dir: /molecule/systemd/tmpfiles_configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.systemd
@@ -102,19 +102,19 @@
     tests_dir: /molecule/systemd/system_configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.systemd

--- a/molecule/telegraf/converge.yml
+++ b/molecule/telegraf/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.telegraf
@@ -42,11 +42,11 @@
     tests_dir: /molecule/telegraf/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             # Play role fully on first run, so that handlers don't breaks
@@ -102,19 +102,19 @@
     tests_dir: /molecule/telegraf/configs
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item.0 }}"
         state: "{{ item.1 }}"
       loop: "{{ ['default', 'defaults', 'exclusive'] | product(['absent', 'directory']) }}"
     - name: Touch existing files
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}/{{ item }}"
         state: touch
       loop: [
         default/state_absent_existing, default/state_ignore_existing,
         exclusive/existing, exclusive/existing_present, exclusive/existing_ignore,
       ]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Default
           ansible.builtin.import_role:
             name: manala.roles.telegraf

--- a/molecule/timezone/converge.yml
+++ b/molecule/timezone/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.timezone

--- a/molecule/vault_cli/converge.yml
+++ b/molecule/vault_cli/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.vault_cli
@@ -30,11 +30,11 @@
     tests_dir: /molecule/vault_cli/version
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Fixed
           ansible.builtin.import_role:
             name: manala.roles.vault_cli

--- a/molecule/vim/converge.yml
+++ b/molecule/vim/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.vim
@@ -30,11 +30,11 @@
     tests_dir: /molecule/vim/config
   tasks:
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role - Dict
           ansible.builtin.import_role:
             name: manala.roles.vim

--- a/molecule/yarn/converge.yml
+++ b/molecule/yarn/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.yarn

--- a/molecule/zsh/converge.yml
+++ b/molecule/zsh/converge.yml
@@ -8,7 +8,7 @@
   tags: [default]
   hosts: debian
   tasks:
-    - block:  # noqa name[missing]
+    - block:  # noqa: name[missing]
         - name: Role
           ansible.builtin.import_role:
             name: manala.roles.zsh

--- a/roles/ansible_galaxy/tasks/roles.yml
+++ b/roles/ansible_galaxy/tasks/roles.yml
@@ -30,6 +30,7 @@
       --roles-path={{ manala_ansible_galaxy_roles_path | ternary(manala_ansible_galaxy_roles_path, '/etc/ansible/roles') }}
       {{ manala_ansible_galaxy_force | ternary('--force', '') }}
   when: manala_ansible_galaxy_roles | length
+  changed_when: true
 
 - name: Roles > Clean requirements
   ansible.builtin.file:

--- a/roles/apt/tasks/keys.yml
+++ b/roles/apt/tasks/keys.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Keys > Keys
-  ansible.builtin.apt_key:  # noqa args[module]
+  ansible.builtin.apt_key:  # noqa: args[module]
     id: "{{ item.id }}"
     url: "{{ item.url | default(omit) }}"
     keyserver: "{{ item.keyserver | default(omit) }}"

--- a/roles/apt/tasks/packages.yml
+++ b/roles/apt/tasks/packages.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Packages > Apt
-  ansible.builtin.apt:  # noqa args[module]
+  ansible.builtin.apt:  # noqa: args[module]
     deb: "{{ item.package if (item.deb) else omit }}"
     name: "{{ item.package if (not item.deb) else omit }}"
     state: "{{ item.state }}"

--- a/roles/apt/tasks/repositories.yml
+++ b/roles/apt/tasks/repositories.yml
@@ -60,7 +60,7 @@
   register: __manala_apt_repositories_absents_results
 
 - name: Repositories > Update cache
-  ansible.builtin.apt:  # noqa no-handler
+  ansible.builtin.apt:  # noqa: no-handler
     update_cache: true
   when: __manala_apt_repositories_presents_results is changed
     or __manala_apt_repositories_absents_results is changed

--- a/roles/apt/tasks/update.yml
+++ b/roles/apt/tasks/update.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Update > Backup package marks
-  ansible.builtin.shell:  # noqa risky-shell-pipe no-tabs
+  ansible.builtin.shell:  # noqa: risky-shell-pipe no-tabs
     cmd: >
       dpkg --get-selections {{ item }}
       | cut -f 2-
@@ -11,13 +11,14 @@
   register: __manala_apt_update_marks_results
 
 - name: Update > Hold packages
-  ansible.builtin.shell:  # noqa risky-shell-pipe
+  ansible.builtin.shell:  # noqa: risky-shell-pipe
     cmd: >
       echo '{{ item.0 }} hold'
       | dpkg --set-selections
   when:
     - item.1
     - item.1 != 'hold'
+  changed_when: true
   loop: |
     {{
       manala_apt_update_holds
@@ -33,11 +34,12 @@
     update_cache: true
 
 - name: Update > Restore package marks
-  ansible.builtin.shell:  # noqa risky-shell-pipe
+  ansible.builtin.shell:  # noqa: risky-shell-pipe
     cmd: >
       echo '{{ item.0 }} {{ item.1 }}'
       | dpkg --set-selections
   when: item.1
+  changed_when: true
   loop: |
     {{
       manala_apt_update_holds

--- a/roles/aptly/tasks/repositories.yml
+++ b/roles/aptly/tasks/repositories.yml
@@ -57,6 +57,7 @@
       )
     }}"
   when: item.name not in __manala_aptly_repositories_local_find_output.stdout_lines
+  changed_when: true
   loop: "{{
     manala_aptly_repositories
       | flatten
@@ -73,6 +74,7 @@
           -label={{ item.label }} {{ item.name }}{{ manala_aptly_user | ternary('\"', '')
     }}"
   when: item.name not in __manala_aptly_repositories_published_find_output.stdout_lines
+  changed_when: true
   loop: "{{
     manala_aptly_repositories
       | flatten

--- a/roles/deploy/tasks/copied.yml
+++ b/roles/deploy/tasks/copied.yml
@@ -17,3 +17,4 @@
   loop_control:
     index_var: index
   when: __manala_deploy_copied_stats_output.results[index].stat.exists
+  changed_when: true

--- a/roles/deploy/tasks/shared.yml
+++ b/roles/deploy/tasks/shared.yml
@@ -13,7 +13,7 @@
   loop: "{{ manala_deploy_shared_files }}"
 
 - name: Shared > Ensure shared directories files are present
-  ansible.builtin.file:  # noqa risky-file-permissions
+  ansible.builtin.file:  # noqa: risky-file-permissions
     path: "{{ (deploy_helper.shared_path ~ '/' ~ item) | dirname }}"
     state: directory
   loop: "{{ manala_deploy_shared_files | flatten }}"
@@ -22,7 +22,7 @@
   when: not __manala_deploy_shared_files_stats_output.results[index].stat.exists
 
 - name: Shared > Ensure shared files are present
-  ansible.builtin.file:  # noqa risky-file-permissions
+  ansible.builtin.file:  # noqa: risky-file-permissions
     path: "{{ deploy_helper.shared_path ~ '/' ~ item }}"
     state: touch
   loop: "{{ manala_deploy_shared_files | flatten }}"
@@ -31,7 +31,7 @@
   when: not __manala_deploy_shared_files_stats_output.results[index].stat.exists
 
 - name: Shared > Ensure shared dirs are present
-  ansible.builtin.file:  # noqa risky-file-permissions
+  ansible.builtin.file:  # noqa: risky-file-permissions
     path: "{{ deploy_helper.shared_path ~ '/' ~ item }}"
     state: directory
     follow: true

--- a/roles/deploy/tasks/strategy/git.yml
+++ b/roles/deploy/tasks/strategy/git.yml
@@ -14,7 +14,7 @@
         update: true
 
     - name: Strategy / Git > Get head
-      ansible.builtin.command:  # noqa command-instead-of-module
+      ansible.builtin.command:  # noqa: command-instead-of-module
         cmd: git rev-parse --short HEAD
       args:
         chdir: "{{ deploy_helper.shared_path ~ '/cached-copy' }}"
@@ -26,7 +26,7 @@
         manala_deploy_strategy_git_head: "{{ __manala_deploy_strategy_git_head_result.stdout }}"
 
     - name: Strategy / Git > Export repository
-      ansible.builtin.command:  # noqa command-instead-of-module
+      ansible.builtin.command:  # noqa: command-instead-of-module
         cmd: git checkout-index -f -a --prefix="{{ deploy_helper.new_release_path }}/"
       args:
         chdir: "{{ deploy_helper.shared_path ~ '/cached-copy' }}"

--- a/roles/deploy/tasks/strategy/unarchive.yml
+++ b/roles/deploy/tasks/strategy/unarchive.yml
@@ -6,7 +6,7 @@
   block:
 
     - name: Strategy / Unarchive > Create dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ deploy_helper.new_release_path }}/"
         state: directory
 

--- a/roles/deploy/tasks/tasks/install_composer.yml
+++ b/roles/deploy/tasks/tasks/install_composer.yml
@@ -21,6 +21,7 @@
       ansible.builtin.command:
         cmd: "php /tmp/installer --install-dir=\"{{ item.shared_dir }}\" --filename=\"composer\" --disable-tls"
       when: not __manala_deploy_composer_bin_stat_result.stat.exists
+      changed_when: true
 
     - name: Tasks / Install Composer > Remove installer
       ansible.builtin.file:

--- a/roles/deploy/tasks/tasks/symfony_assets_version_file.yml
+++ b/roles/deploy/tasks/tasks/symfony_assets_version_file.yml
@@ -14,7 +14,7 @@
         }}"
 
     - name: Tasks / Symfony Assets Version File > Generate assets_version.yml
-      ansible.builtin.copy:  # noqa risky-file-permissions
+      ansible.builtin.copy:  # noqa: risky-file-permissions
         dest: "{{ item.dir }}/app/config/assets_version.yml"
         force: true
         content: |

--- a/roles/deploy/tasks/unfinished.yml
+++ b/roles/deploy/tasks/unfinished.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Unfinished > Add an unfinished file, to allow cleanup on successful finalize
-  ansible.builtin.file:  # noqa risky-file-permissions
+  ansible.builtin.file:  # noqa: risky-file-permissions
     path: "{{ deploy_helper.new_release_path }}/{{ deploy_helper.unfinished_filename }}"
     state: touch

--- a/roles/deploy/tasks/writable/dirs.yml
+++ b/roles/deploy/tasks/writable/dirs.yml
@@ -17,6 +17,7 @@
 - name: Writable / Dirs > Raw {{ item.dir | quote }}
   ansible.builtin.raw: "{{ item.raw | format(dir=deploy_helper.new_release_path ~ '/' ~ item.dir) }}"
   when: item.raw is defined
+  changed_when: true
   loop: |
     {{ query(
       'manala.roles.deploy_writable_dirs',

--- a/roles/docker/tasks/update.yml
+++ b/roles/docker/tasks/update.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Update > Pull
-  ansible.builtin.shell:  # noqa risky-shell-pipe
+  ansible.builtin.shell:  # noqa: risky-shell-pipe
     cmd: |
       docker images \
         | awk '/^REPOSITORY|\<none\>/ {next} {print $1":"$2}' \

--- a/roles/mysql/tasks/data.yml
+++ b/roles/mysql/tasks/data.yml
@@ -22,3 +22,4 @@
     - manala_mysql_server
     - manala_mysql_data_dir_initialize
     - __manala_mysql_data_dir_create_result is changed
+  changed_when: true

--- a/roles/mysql/tasks/data_dir.yml
+++ b/roles/mysql/tasks/data_dir.yml
@@ -22,3 +22,4 @@
     - manala_mysql_server
     - manala_mysql_data_dir_initialize
     - __manala_mysql_data_dir_create_result is changed
+  changed_when: true

--- a/roles/network/tasks/routing_tables.yml
+++ b/roles/network/tasks/routing_tables.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Routing Tables > File
-  ansible.builtin.lineinfile:  # noqa no-tabs
+  ansible.builtin.lineinfile:  # noqa: no-tabs
     path: "{{ manala_network_routing_tables_file }}"
     regexp: "^{{ item.key }}\\s+"
     line: "{{ item.key ~ '\t' ~ item.value }}"

--- a/roles/npm/tasks/update.yml
+++ b/roles/npm/tasks/update.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Update > Packages
-  community.general.npm:  # noqa package-latest
+  community.general.npm:  # noqa: package-latest
     global: true
     state: latest

--- a/roles/ohmyzsh/tasks/requirements.yml
+++ b/roles/ohmyzsh/tasks/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Requirements > Git check
-  ansible.builtin.command:  # noqa command-instead-of-module
+  ansible.builtin.command:  # noqa: command-instead-of-module
     cmd: git --version
   check_mode: false
   failed_when: false

--- a/roles/php/tasks/install.yml
+++ b/roles/php/tasks/install.yml
@@ -86,7 +86,7 @@
 
     # Use debfoster to find out each package dependencies
     - name: Install > Exclusive - Find packages dependencies
-      ansible.builtin.shell:  # noqa risky-shell-pipe
+      ansible.builtin.shell:  # noqa: risky-shell-pipe
         cmd: |
           for package in {{
             query(

--- a/roles/timezone/tasks/default.yml
+++ b/roles/timezone/tasks/default.yml
@@ -36,7 +36,8 @@
   register: __manala_timezone_default_link_result
 
 - name: Default > Reconfigure tzdata
-  ansible.builtin.command:  # noqa no-handler
+  ansible.builtin.command:  # noqa: no-handler
     cmd: dpkg-reconfigure --frontend noninteractive tzdata
   when: __manala_timezone_default_content_result | default({}) is changed
     or __manala_timezone_default_link_result | default({}) is changed
+  changed_when: true

--- a/tests/integration/targets/files_attributes/tasks/main.yml
+++ b/tests/integration/targets/files_attributes/tasks/main.yml
@@ -6,9 +6,9 @@
 
 - vars:
     tests_dir: /tmp/integration/files_attributes/touch
-  block:  # noqa name[missing]
+  block:  # noqa: name[missing]
     - name: Clean tests dir
-      ansible.builtin.file:  # noqa risky-file-permissions
+      ansible.builtin.file:  # noqa: risky-file-permissions
         path: "{{ tests_dir }}"
         state: "{{ item }}"
       loop: [absent, directory]


### PR DESCRIPTION
This change went unnoticed, but from now on, noqa tags must ends with colons

Before
```yaml
# noqa foo bar
```

After
```yaml
# noqa: foo bar
```
