### PR TITLE
Add galaxy tags

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -29,7 +29,18 @@ license:
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
-tags: []
+tags:
+  - application
+  - cloud
+  - database
+  - infrastructure
+  - linux
+  - monitoring
+  - networking
+  - security
+  - storage
+  - tools
+  - debian
 
 # Collections that this collection requires to be installed for it to be usable. The key of the dict is the
 # collection label 'namespace.name'. The value is a version range


### PR DESCRIPTION
According to `galaxy[tags]` lint rule (see: https://ansible-lint.readthedocs.io/rules/galaxy/) galaxy collection tags are now required.