### PR TITLE
[Network] Add Netplan configs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [Redis] Version 7.0 support (bullseye and bookworm)
 - [Apt] Add GlusterFS 10.4 repository
 - [Apt] Add Maxscale 23.02 support
+- [Network] Add Netplan configs support
 
 ## [3.6.0] - 2023-05-16
 ### Added

--- a/molecule/network/converge.yml
+++ b/molecule/network/converge.yml
@@ -266,3 +266,45 @@
             cmd: goss --gossfile - validate
             stdin: "{{ lookup('ansible.builtin.template', 'goss/routing_tables.yml.j2') }}"
           changed_when: false
+
+###################
+# Netplan Configs #
+###################
+
+- name: Netplan Configs
+  tags: [netplan_configs]
+  hosts: debian
+  vars:
+    tests_dir: /molecule/network/netplan_configs
+  tasks:
+    - name: Clean tests dir
+      ansible.builtin.file:  # noqa: risky-file-permissions
+        path: "{{ tests_dir }}/{{ item.0 }}"
+        state: "{{ item.1 }}"
+      loop: "{{ ['default'] | product(['absent', 'directory']) }}"
+    - block:  # noqa: name[missing]
+        - name: Role - Default
+          ansible.builtin.import_role:
+            name: manala.roles.network
+          vars:
+            manala_network_install_packages:
+              - netplan.io
+            manala_network_netplan_configs_apply: false
+            manala_network_netplan_configs_exclusive: false
+            manala_network_netplan_configs_dir: "{{ tests_dir }}/default"
+            manala_network_netplan_configs_defaults: {}
+            manala_network_netplan_configs:
+              # Content
+              - file: content
+                config: |
+                  Content
+              # Template
+              - file: template
+                template: fixtures/template.j2
+              - template: fixtures/template_file.j2
+      always:
+        - name: Goss
+          ansible.builtin.command:
+            cmd: goss --gossfile - validate
+            stdin: "{{ lookup('ansible.builtin.template', 'goss/netplan_configs.yml.j2') }}"
+          changed_when: false

--- a/molecule/network/goss/interfaces_configs.yml.j2
+++ b/molecule/network/goss/interfaces_configs.yml.j2
@@ -1,7 +1,6 @@
 ---
 
 file:
-
   # Default - Content
   {{ tests_dir }}/default/content:
     exists: true

--- a/molecule/network/goss/netplan_configs.yml.j2
+++ b/molecule/network/goss/netplan_configs.yml.j2
@@ -1,0 +1,33 @@
+---
+
+package:
+  netplan.io:
+    installed: true
+
+file:
+  # Default - Content
+  {{ tests_dir }}/default/content:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0600"
+    contains:
+      - "/^Content$/"
+  # Default - Template
+  {{ tests_dir }}/default/template:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0600"
+    contains:
+      - "/^Template$/"
+  {{ tests_dir }}/default/template_file:
+    exists: true
+    filetype: file
+    owner: root
+    group: root
+    mode: "0600"
+    contains:
+      - "/^Template file$/"

--- a/roles/network/README.md
+++ b/roles/network/README.md
@@ -99,6 +99,25 @@ manala_network_interfaces_configs:
   - "{{ my_custom_interfaces_configs_array }}"
 ```
 
+#### Netplan configurations
+
+```yaml
+manala_network_netplan_configs_apply: true # Default behavior, generate and applying netplan configurations
+manala_network_install_packages:
+  - netplan.io
+manala_network_netplan_configs:
+  - file: 90-default.yaml
+    config: |
+      network:
+        version: 2
+        ethernets:
+          all-en:
+            match:
+              name: en*
+            dhcp4: true
+            dhcp6: true
+```
+
 ## Example playbook
 
 ```yaml

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -28,3 +28,10 @@ manala_network_interfaces_configs: []
 # Routing Tables
 manala_network_routing_tables_file: /etc/iproute2/rt_tables
 manala_network_routing_tables: {}
+
+# Netplan configs
+manala_network_netplan_configs_exclusive: false
+manala_network_netplan_configs_dir: /etc/netplan
+manala_network_netplan_configs_defaults: {}
+manala_network_netplan_configs: []
+manala_network_netplan_configs_apply: true

--- a/roles/network/handlers/main.yml
+++ b/roles/network/handlers/main.yml
@@ -8,3 +8,11 @@
     - networking
   # Deprecated
   listen: networking restart
+
+- name: Generate netplan
+  ansible.builtin.command: netplan generate
+  notify: Apply netplan
+
+- name: Apply netplan
+  ansible.builtin.command: netplan apply
+  when: manala_network_netplan_configs_apply

--- a/roles/network/meta/main.yml
+++ b/roles/network/meta/main.yml
@@ -20,3 +20,4 @@ galaxy_info:
   galaxy_tags:
     - system
     - network
+    - netplan

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -35,3 +35,9 @@
   tags:
     - manala_network
     - manala_network.routing_tables
+
+- name: Netplan configs
+  ansible.builtin.import_tasks: netplan_configs.yml
+  tags:
+    - manala_network
+    - manala_network.netplan_configs

--- a/roles/network/tasks/netplan_configs.yml
+++ b/roles/network/tasks/netplan_configs.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Netplan Configs > Exclusive
+  ansible.builtin.find:
+    path: "{{ manala_network_netplan_configs_dir }}"
+    file_type: file
+    patterns: "*"
+  changed_when: false
+  register: __manala_network_netplan_configs_exclusive_find
+  when: manala_network_netplan_configs_exclusive
+
+- name: Netplan Configs > Templates present
+  ansible.builtin.template:
+    src: "{{ item.template }}"
+    dest: "{{ item.file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  loop: |
+    {{ query(
+      'manala.roles.templates_exclusive',
+      manala_network_netplan_configs,
+      __manala_network_netplan_configs_exclusive_find.files | default([]),
+      manala_network_netplan_configs_dir,
+      manala_network_netplan_configs_defaults.template | default('netplan_configs/_default.j2', true),
+      wantstate='present'
+    ) }}
+  notify:
+    - Generate netplan
+
+- name: Netplan Configs > Files absent
+  ansible.builtin.file:
+    path: "{{ item.file }}"
+    state: absent
+  loop: |
+    {{ query(
+      'manala.roles.templates_exclusive',
+      manala_network_netplan_configs,
+      __manala_network_netplan_configs_exclusive_find.files | default([]),
+      manala_network_netplan_configs_dir,
+      manala_network_netplan_configs_defaults.template | default('netplan_configs/_default.j2', true),
+      wantstate='absent'
+    ) }}
+  notify:
+    - Generate netplan

--- a/roles/network/templates/netplan_configs/_default.j2
+++ b/roles/network/templates/netplan_configs/_default.j2
@@ -1,0 +1,7 @@
+{%- set config = item.config | default('') -%}
+
+{%- if config is string -%}
+{{ config }}
+{%- else -%}
+{{ config | to_yaml }}
+{%- endif -%}


### PR DESCRIPTION
Debian Bookworm network is managed by Netplan + systemd-networkd. 

This PR add support netplan configuration files.