### PR TITLE
fix: README bind zone examples

### DIFF
--- a/roles/bind/README.md
+++ b/roles/bind/README.md
@@ -85,7 +85,7 @@ manala_bind_zones:
                   86400   ; minimum (1 day)
                   )
       @  IN NS  ns.bar.local.
-      ns IN A   172.16.1.1";
+      ns IN A   172.16.1.1
   - zone: baz.local
     state: absent
   - zone: qux.local
@@ -122,7 +122,7 @@ manala_bind_zones:
                   86400   ; minimum (1 day)
                   )
       @  IN NS  ns.foo.local.
-      ns IN A   172.16.1.1";
+      ns IN A   172.16.1.1
     records:
       - { record: bar, value: 172.16.1.123 }
 ```


### PR DESCRIPTION
I think there are syntax errors in the examples for bind zone content. When I try to apply such examples I get this in the syslog:
```
Nov 23 14:50:07 ubuntu named[9780]: dns_rdata_fromtext: /var/cache/bind/db.bar.local:9: extra input text
```