### PR TITLE
Fix Mount

### DIFF
--- a/molecule/mount/converge.yml
+++ b/molecule/mount/converge.yml
@@ -25,8 +25,8 @@
             tasks_from: points
           vars:
             manala_mount_points:
-              - path: "{{ tests_dir }}/ignore"
-                state: ignore
+              - path: "{{ tests_dir }}/absent"
+                state: absent
               # Flatten
               -
                 - path: "{{ tests_dir }}/bind"

--- a/molecule/mount/goss/points.yaml.j2
+++ b/molecule/mount/goss/points.yaml.j2
@@ -1,7 +1,7 @@
 ---
 
 file:
-  {{ tests_dir }}/ignore:
+  {{ tests_dir }}/absent:
     exists: false
   {{ tests_dir }}/directory/file:
     exists: true

--- a/roles/mount/tasks/points.yaml
+++ b/roles/mount/tasks/points.yaml
@@ -3,8 +3,8 @@
 - name: Points > Mounts
   ansible.posix.mount:
    name: "{{ item.path }}"
-   fstype: "{{ item.fstype }}"
-   src: "{{ item.src }}"
+   fstype: "{{ item.fstype | default(omit) }}"
+   src: "{{ item.src | default(omit) }}"
    opts: "{{ item.opts | default(omit) }}"
    state: "{{ item.state | default('mounted') }}"
   loop: "{{


### PR DESCRIPTION
Since https://github.com/manala/ansible-roles/pull/697 we don't filter only on `present` mount points, so it doesn't make sense to keep `fstype` and `src` required, cause we can know `absent` mount points.

Fix the test to reflect that