### PR TITLE
[All] Mainly buster related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [Apt] Fix buster backports/backports_sloppy debian repository uris
+
 ## [4.2.0] - 2024-09-04
 ### Added
 - [Apt] Add HAProxy 3.0 repository

--- a/molecule/maxscale.23.02/converge.yml
+++ b/molecule/maxscale.23.02/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - block:  # noqa: name[missing]
         - name: Role

--- a/molecule/maxscale.23.02/prepare.yml
+++ b/molecule/maxscale.23.02/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/maxscale.23.08/converge.yml
+++ b/molecule/maxscale.23.08/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - block:  # noqa: name[missing]
         - name: Role
@@ -25,7 +27,9 @@
 
 - name: Config
   tags: [config]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     tests_dir: /molecule/maxscale/config
   tasks:
@@ -65,7 +69,9 @@
 
 - name: Configs
   tags: [configs]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     tests_dir: /molecule/maxscale/configs
   tasks:
@@ -156,7 +162,9 @@
 
 - name: Users
   tags: [users]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     tests_dir: /molecule/maxscale/users
   tasks:

--- a/molecule/maxscale.23.08/prepare.yml
+++ b/molecule/maxscale.23.08/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.5.6/converge.yml
+++ b/molecule/php.5.6/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 5.6
   tasks:
@@ -80,7 +82,9 @@
 
 - name: Exclusive
   tags: [exclusive]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 5.6
   tasks:
@@ -122,7 +126,9 @@
 
 - name: Configs
   tags: [configs]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 5.6
     tests_dir: /molecule/php/configs
@@ -252,7 +258,9 @@
 
 - name: Fpm Pools
   tags: [fpm_pools]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 5.6
     tests_dir: /molecule/php/fpm_pools

--- a/molecule/php.5.6/prepare.yml
+++ b/molecule/php.5.6/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.7.0/converge.yml
+++ b/molecule/php.7.0/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.0
   tasks:

--- a/molecule/php.7.0/prepare.yml
+++ b/molecule/php.7.0/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.7.1/converge.yml
+++ b/molecule/php.7.1/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.1
   tasks:

--- a/molecule/php.7.1/prepare.yml
+++ b/molecule/php.7.1/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.7.2/converge.yml
+++ b/molecule/php.7.2/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.2
   tasks:

--- a/molecule/php.7.2/prepare.yml
+++ b/molecule/php.7.2/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.7.3/converge.yml
+++ b/molecule/php.7.3/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.3
   tasks:

--- a/molecule/php.7.3/prepare.yml
+++ b/molecule/php.7.3/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.7.4/converge.yml
+++ b/molecule/php.7.4/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.4
   tasks:
@@ -80,7 +82,9 @@
 
 - name: Exclusive
   tags: [exclusive]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.4
   tasks:
@@ -122,7 +126,9 @@
 
 - name: Configs
   tags: [configs]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.4
     tests_dir: /molecule/php/configs
@@ -252,7 +258,9 @@
 
 - name: Fpm Pools
   tags: [fpm_pools]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 7.4
     tests_dir: /molecule/php/fpm_pools

--- a/molecule/php.7.4/prepare.yml
+++ b/molecule/php.7.4/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.8.0/converge.yml
+++ b/molecule/php.8.0/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 8.0
   tasks:

--- a/molecule/php.8.0/prepare.yml
+++ b/molecule/php.8.0/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.8.1/converge.yml
+++ b/molecule/php.8.1/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 8.1
   tasks:

--- a/molecule/php.8.1/prepare.yml
+++ b/molecule/php.8.1/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.8.2/converge.yml
+++ b/molecule/php.8.2/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 8.2
   tasks:

--- a/molecule/php.8.2/prepare.yml
+++ b/molecule/php.8.2/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/php.8.3/converge.yml
+++ b/molecule/php.8.3/converge.yml
@@ -6,7 +6,9 @@
 
 - name: Default
   tags: [default]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 8.3
   tasks:
@@ -80,7 +82,9 @@
 
 - name: Exclusive
   tags: [exclusive]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 8.3
   tasks:
@@ -122,7 +126,9 @@
 
 - name: Configs
   tags: [configs]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 8.3
     tests_dir: /molecule/php/configs
@@ -252,7 +258,9 @@
 
 - name: Fpm Pools
   tags: [fpm_pools]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   vars:
     manala_php_version: 8.3
     tests_dir: /molecule/php/fpm_pools

--- a/molecule/php.8.3/prepare.yml
+++ b/molecule/php.8.3/prepare.yml
@@ -2,7 +2,9 @@
 
 - name: Prepare
   tags: [always]
-  hosts: debian
+  hosts:
+    - debian
+    - "!debian.buster"
   tasks:
     - name: Apt
       ansible.builtin.import_role:

--- a/molecule/postgresql.9.4/converge.yml
+++ b/molecule/postgresql.9.4/converge.yml
@@ -19,6 +19,7 @@
               local   all             postgres                                peer
               # Trust all IPv4 local connections
               host    all             all             127.0.0.1/32            trust
+              host    all             all             ::1/128                 trust
             manala_postgresql_roles:
               - role: foo
                 password: ~

--- a/roles/apt/vars/main.yaml
+++ b/roles/apt/vars/main.yaml
@@ -42,13 +42,13 @@ manala_apt_repositories_patterns:
     components: "{{ manala_apt_components | flatten | join(' ') }}"
     legacy_file: deb_debian_org_debian.list
   backports:
-    uris: http://deb.debian.org/debian
+    uris: "{{ (ansible_facts.distribution_release in ['buster']) | ternary('http://archive.debian.org/debian', 'http://deb.debian.org/debian') }}"
     suites: "{{ ansible_facts.distribution_release }}-backports"
     components: "{{ manala_apt_components | flatten | join(' ') }}"
     pin: release n={{ ansible_facts.distribution_release }}-backports
     legacy_file: deb_debian_org_debian.list
   backports_sloppy:
-    uris: http://deb.debian.org/debian
+    uris: "{{ (ansible_facts.distribution_release in ['buster']) | ternary('http://archive.debian.org/debian', 'http://deb.debian.org/debian') }}"
     suites: "{{ ansible_facts.distribution_release }}-backports-sloppy"
     components: "{{ manala_apt_components | flatten | join(' ') }}"
     pin: release n={{ ansible_facts.distribution_release }}-backports-sloppy


### PR DESCRIPTION
- Fix buster backports/backports_sloppy debian repository uris
- Remove MaxScale 23.02/23.08 buster tests
- Remove all php versions buster tests
- Allow both ipv4/ipv6 local postgresql connections