### PR TITLE
[Fail2ban] Fix Bookworm sshd jail by installing python3-systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Fail2ban] Fix Bookworm sshd jail by installing python3-systemd
 
 ## [4.2.1] - 2024-09-17
 ### Fixed

--- a/molecule/fail2ban/converge.yml
+++ b/molecule/fail2ban/converge.yml
@@ -14,8 +14,6 @@
             name: manala.roles.fail2ban
           vars:
             manala_fail2ban_config: |
-              [ssh]
-              enabled = false
               [sshd]
               enabled = false
       always:

--- a/molecule/fail2ban/goss/default.yaml.j2
+++ b/molecule/fail2ban/goss/default.yaml.j2
@@ -3,6 +3,9 @@
 package:
   fail2ban:
     installed: true
+  # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=770171
+  python3-systemd:
+    installed: {{ (ansible_facts.distribution_release in ['bookworm']) | ternary('true', 'false') }}
 
 service:
   fail2ban:

--- a/roles/fail2ban/tasks/install.yaml
+++ b/roles/fail2ban/tasks/install.yaml
@@ -7,4 +7,12 @@
     update_cache: true
     cache_valid_time: 3600
   loop:
-    - "{{ manala_fail2ban_install_packages | default(manala_fail2ban_install_packages_default, True) }}"
+    # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=770171
+    - |
+      {{
+        manala_fail2ban_install_packages | default(manala_fail2ban_install_packages_default, True)
+        + (ansible_facts.distribution_release in ['bookworm']) | ternary(
+            ['python3-systemd'],
+            []
+        )
+      }}


### PR DESCRIPTION
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=770171