### PR TITLE
[MySQL] Supports `tls_requires` directive on `manala_mysql_users`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [MySQL] Supports `tls_requires` directive on `manala_mysql_users`
 
 ## [4.5.0] - 2025-06-03
 ### Added

--- a/roles/mysql/tasks/users.yaml
+++ b/roles/mysql/tasks/users.yaml
@@ -13,6 +13,7 @@
     login_unix_socket: "{{ item.login_unix_socket | default(omit) }}"
     login_user: "{{ item.login_user | default(omit) }}"
     login_password: "{{ item.login_password | default(omit) }}"
+    tls_requires: "{{ item.tls_requires | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
   loop: "{{
     manala_mysql_users


### PR DESCRIPTION
Allow to provision MySQL/MariaDB users with TLS requirements.