### PR TITLE
[MySQL] Supports `sql_log_bin` directive on `manala_mysql_databases`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [MySQL] Supports `tls_requires` directive on `manala_mysql_users`
+- [MySQL] Supports `sql_log_bin` directive on `manala_mysql_databases`
 
 ## [4.5.0] - 2025-06-03
 ### Added

--- a/roles/mysql/tasks/databases.yaml
+++ b/roles/mysql/tasks/databases.yaml
@@ -10,6 +10,7 @@
     login_unix_socket: "{{ item.login_unix_socket | default(omit) }}"
     login_user: "{{ item.login_user | default(omit) }}"
     login_password: "{{ item.login_password | default(omit) }}"
+    sql_log_bin: "{{ item.sql_log_bin | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
   loop: "{{
     manala_mysql_databases


### PR DESCRIPTION
This option requires community.mysql version 3.15.0 or higher. See https://github.com/ansible-collections/community.mysql/pull/723