### PR TITLE
[Files] Fix KeyError 'diff' on latest versions of ansible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [Files] Avoid `KeyError: 'diff'` in `files_attributes` action plugin when wrapped modules do not return a `diff` key (Ansible core 2.20+)
+
 ## [5.5.0] - 2026-04-10
 
 ### Added

--- a/plugins/action/files_attributes.py
+++ b/plugins/action/files_attributes.py
@@ -82,7 +82,7 @@ class ActionModule(ActionBase):
                     task_args=['owner', 'group', 'mode'],
                     task_vars=task_vars)
                 result['changed'] |= parents_result['changed']
-                result['diff'] += [parents_result['diff']]
+                result['diff'] += [parents_result.get('diff', {})]
 
             ############
             # Template #
@@ -97,7 +97,7 @@ class ActionModule(ActionBase):
                     task_args=['force', 'owner', 'group', 'mode'],
                     task_vars=task_vars)
                 result['changed'] |= template_result['changed']
-                result['diff'] += template_result['diff']
+                result['diff'] += template_result.get('diff', [])
 
             ###########
             # Content #
@@ -112,7 +112,7 @@ class ActionModule(ActionBase):
                     task_args=['force', 'owner', 'group', 'mode'],
                     task_vars=task_vars)
                 result['changed'] |= content_result['changed']
-                result['diff'] += content_result['diff']
+                result['diff'] += content_result.get('diff', [])
 
             ########
             # Copy #
@@ -164,7 +164,7 @@ class ActionModule(ActionBase):
                             {'path': path, 'state': 'absent'},
                             task_vars=task_vars)
                         result['changed'] |= absent_result['changed']
-                        result['diff'] += [absent_result['diff']]
+                        result['diff'] += [absent_result.get('diff', {})]
 
                 # Link
                 link_result = self._run_module(
@@ -173,7 +173,7 @@ class ActionModule(ActionBase):
                     task_args=['owner', 'group'],
                     task_vars=task_vars)
                 result['changed'] |= link_result['changed']
-                result['diff'] += link_result['diff']
+                result['diff'] += link_result.get('diff', [])
 
             #############
             # Directory #
@@ -191,7 +191,7 @@ class ActionModule(ActionBase):
                             {'path': path, 'state': 'absent'},
                             task_vars=task_vars)
                         result['changed'] |= absent_result['changed']
-                        result['diff'] += [absent_result['diff']]
+                        result['diff'] += [absent_result.get('diff', {})]
 
                 # Directory
                 directory_result = self._run_module(
@@ -200,7 +200,7 @@ class ActionModule(ActionBase):
                     task_args=['owner', 'group', 'mode'],
                     task_vars=task_vars)
                 result['changed'] |= directory_result['changed']
-                result['diff'] += directory_result['diff']
+                result['diff'] += directory_result.get('diff', [])
 
             ########
             # File #
@@ -218,7 +218,7 @@ class ActionModule(ActionBase):
                             {'path': path, 'state': 'absent'},
                             task_vars=task_vars)
                         result['changed'] |= absent_result['changed']
-                        result['diff'] += [absent_result['diff']]
+                        result['diff'] += [absent_result.get('diff', {})]
 
                 # Create
                 create_result = self._run_module(
@@ -235,7 +235,7 @@ class ActionModule(ActionBase):
                     task_args=['owner', 'group', 'mode'],
                     task_vars=task_vars)
                 result['changed'] |= file_result['changed']
-                result['diff'] += file_result['diff']
+                result['diff'] += file_result.get('diff', [])
 
             # Other...
             else:


### PR DESCRIPTION
The files_attributes action plugin appends inner-module diff output unconditionally via result['diff'] += X['diff']. 
In recent Ansible core versions (observed on 2.20.x), wrapped modules may omit the 'diff' key from their return, causing the whole task to fail with KeyError: 'diff'.

Use .get('diff', ...) with appropriate defaults so the plugin keeps working regardless of whether the inner module returned diff data.