### PR TITLE
[Files] Forward recurse to file module for directory state

### DIFF
--- a/plugins/action/files_attributes.py
+++ b/plugins/action/files_attributes.py
@@ -197,7 +197,7 @@ class ActionModule(ActionBase):
                 directory_result = self._run_module(
                     'ansible.builtin.file',
                     {'path': path, 'state': 'directory'},
-                    task_args=['owner', 'group', 'mode'],
+                    task_args=['recurse', 'owner', 'group', 'mode'],
                     task_vars=task_vars)
                 result['changed'] |= directory_result['changed']
                 result['diff'] += directory_result.get('diff', [])

--- a/tests/integration/targets/files_attributes/tasks/main.yaml
+++ b/tests/integration/targets/files_attributes/tasks/main.yaml
@@ -32,3 +32,39 @@
           - stat.stat.gr_name == 'lazy'
           - stat.stat.pw_name == 'lazy'
           - stat.stat.size == 0
+
+#####################
+# Directory recurse #
+#####################
+
+- vars:
+    tests_dir: /tmp/integration/files_attributes/directory_recurse
+  block:  # noqa: name[missing]
+    - name: Clean tests dir
+      ansible.builtin.file:  # noqa: risky-file-permissions
+        path: "{{ tests_dir }}"
+        state: "{{ item }}"
+      loop: [absent, directory]
+    - name: Nested file with restrictive mode
+      ansible.builtin.file:
+        path: "{{ tests_dir }}/file"
+        state: touch
+        mode: '0600'
+    - name: Module
+      manala.roles.files_attributes:
+        path: "{{ tests_dir }}"
+        state: directory
+        mode: 'u=rwX,g=rX,o=rX'
+        recurse: true
+  always:
+    - name: Stat
+      ansible.builtin.stat:
+        path: "{{ tests_dir }}/file"
+      register: stat
+    - name: Assert
+      ansible.builtin.assert:
+        that:
+          - stat is not failed
+          - stat.stat.exists
+          - stat.stat.isreg
+          - stat.stat.mode == '0644'


### PR DESCRIPTION
Small PR to fix a recurse problem on this manala file role:  

> When `state: directory`, the action plugin called ansible.builtin.file with only owner/group/mode, dropping `recurse`. 
> As a result `recurse: true` was silently ignored for directories, so mode/owner/group were never applied to existing children — only to the directory itself.
> 
> Add `recurse` to the forwarded task args so the declared mode propagates to the directory tree, and cover it with an integration test.