### PR TITLE
[alloy] Add environment support for /etc/default/alloy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [Alloy] Add environment support (`manala_alloy_environment`) for managing `/etc/default/alloy` via lineinfile
+
 ## [5.5.1] - 2026-05-22
 
 ### Fixed

--- a/extensions/molecule/alloy/converge.yml
+++ b/extensions/molecule/alloy/converge.yml
@@ -19,6 +19,45 @@
             stdin: "{{ lookup('ansible.builtin.template', 'goss/default.yaml.j2') }}"
           changed_when: false
 
+###############
+# Environment #
+###############
+
+- name: Environment
+  tags: [environment]
+  hosts: debian
+  vars:
+    tests_dir: /molecule/alloy/environment
+  tasks:
+    - name: Clean tests dir  # noqa: risky-file-permissions
+      ansible.builtin.file:
+        path: "{{ tests_dir }}"
+        state: "{{ item }}"
+      loop: [absent, directory]
+    - name: Prepare test file
+      ansible.builtin.copy:
+        dest: "{{ tests_dir }}/custom_args"
+        mode: "0644"
+        content: |
+          CONFIG_FILE="/etc/alloy/config.alloy"
+          CUSTOM_ARGS=""
+          RESTART_ON_UPGRADE=true
+    - block:  # noqa: name[missing]
+        - name: Role - CUSTOM_ARGS
+          ansible.builtin.import_role:
+            name: manala.roles.alloy
+            tasks_from: environment
+          vars:
+            manala_alloy_environment_file: "{{ tests_dir }}/custom_args"
+            manala_alloy_environment:
+              CUSTOM_ARGS: --disable-reporting
+      always:
+        - name: Goss
+          ansible.builtin.command:
+            cmd: goss --gossfile - validate
+            stdin: "{{ lookup('ansible.builtin.template', 'goss/environment.yaml.j2') }}"
+          changed_when: false
+
 ##########
 # Config #
 ##########

--- a/extensions/molecule/alloy/goss/environment.yaml.j2
+++ b/extensions/molecule/alloy/goss/environment.yaml.j2
@@ -1,0 +1,10 @@
+---
+
+file:
+  {{ tests_dir }}/custom_args:
+    exists: true
+    filetype: file
+    contents:
+      - CONFIG_FILE="/etc/alloy/config.alloy"
+      - CUSTOM_ARGS="--disable-reporting"
+      - RESTART_ON_UPGRADE=true

--- a/roles/alloy/defaults/main.yaml
+++ b/roles/alloy/defaults/main.yaml
@@ -9,3 +9,7 @@ manala_alloy_install_packages_default:
 manala_alloy_config_file: /etc/alloy/config.alloy
 manala_alloy_config_template: ~
 manala_alloy_config: ~
+
+# Environment
+manala_alloy_environment_file: /etc/default/alloy
+manala_alloy_environment: {}

--- a/roles/alloy/tasks/environment.yaml
+++ b/roles/alloy/tasks/environment.yaml
@@ -1,0 +1,9 @@
+---
+
+- name: Environment > CUSTOM_ARGS
+  ansible.builtin.lineinfile:
+    path: "{{ manala_alloy_environment_file }}"
+    regexp: ^CUSTOM_ARGS=
+    line: CUSTOM_ARGS="{{ manala_alloy_environment.CUSTOM_ARGS | default('') }}"
+  register: __manala_alloy_environment_result
+  when: manala_alloy_environment.CUSTOM_ARGS is defined

--- a/roles/alloy/tasks/main.yaml
+++ b/roles/alloy/tasks/main.yaml
@@ -12,6 +12,12 @@
     - manala_alloy
     - manala_alloy.config
 
+- name: Environment
+  ansible.builtin.import_tasks: environment.yaml
+  tags:
+    - manala_alloy
+    - manala_alloy.environment
+
 - name: Services
   ansible.builtin.import_tasks: services.yaml
   tags:

--- a/roles/alloy/tasks/services.yaml
+++ b/roles/alloy/tasks/services.yaml
@@ -8,6 +8,7 @@
         'restarted'
           if (
             __manala_alloy_config_template_result | default({}) is changed
+            or __manala_alloy_environment_result | default({}) is changed
           ) else
         'started'
       }}


### PR DESCRIPTION
Allow managing CUSTOM_ARGS via lineinfile to preserve the package default file while enabling flags like --disable-reporting.